### PR TITLE
EZP-24048: Don't clear legacy content cache on symfony cache:clear

### DIFF
--- a/bundle/Cache/LegacyCachePurger.php
+++ b/bundle/Cache/LegacyCachePurger.php
@@ -19,8 +19,8 @@ use eZScript;
 use eZCache;
 
 /**
- * Purger for legacy cache.
- * Hooks into cache:clear command.
+ * Purger for legacy file based cache.
+ * Hooks into cache:clear command, which again is used by composer install and update.
  */
 class LegacyCachePurger implements CacheClearerInterface
 {
@@ -77,7 +77,7 @@ class LegacyCachePurger implements CacheClearerInterface
                         )
                     )
                 );
-                $helper->clearItems( eZCache::fetchList(), false );
+                $helper->clearItems( eZCache::fetchByTag( "template,ini,i18n" ), "Legacy file cache (Template, ini and i18n)" );
             },
             false,
             false


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-24048

This is also used on composer install/update, but it is not clearing content (http + stash) cache for platform stack, so would make sense to align handling in LegacyBridge/Bundle as well to avoid slow operation and  impact on performance. Instead asking users (like always), to selectively clear content based cache based on the changes they deploy.


#### Testing on eZ Publish 5.x (and not master, aka 6.x, aka eZ Platform)
If you are on eZ Publish 5.x, then apply this fix to [vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishLegacyBundle/Cache/LegacyCachePurger.php](https://github.com/ezsystems/ezpublish-kernel/blob/v2014.11.0/eZ/Bundle/EzPublishLegacyBundle/Cache/LegacyCachePurger.php)