### PR TITLE
Fix EZP-23953: Legacy session events not triggered any more

### DIFF
--- a/bundle/DependencyInjection/Compiler/LegacySessionPass.php
+++ b/bundle/DependencyInjection/Compiler/LegacySessionPass.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * This file is part of the eZ Publish LegacyBridge package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Proxies configured session storage and session save handler services.
+ */
+class LegacySessionPass implements CompilerPassInterface
+{
+    public function process( ContainerBuilder $container )
+    {
+        if ( !$container->hasAlias( 'session.storage' ) )
+        {
+            return;
+        }
+
+        $sessionStorageAlias = $container->getAlias( 'session.storage' );
+        $sessionStorageProxyDef = $container->findDefinition( 'ezpublish_legacy.session_storage_proxy' );
+        $sessionStorageProxyDef->replaceArgument( 1, new Reference( (string)$sessionStorageAlias ) );
+        $container->setAlias( 'session.storage', 'ezpublish_legacy.session_storage_proxy' );
+
+        $sessionHandlerProxyDef = $container->findDefinition( 'ezpublish_legacy.session_handler_proxy' );
+        if ( $container->hasAlias( 'session.handler' ) )
+        {
+            $sessionHandlerAlias = $container->getAlias( 'session.handler' );
+            $sessionHandlerProxyDef->replaceArgument( 1, new Reference( (string)$sessionHandlerAlias ) );
+        }
+        $container->setAlias( 'session.handler', 'ezpublish_legacy.session_handler_proxy' );
+    }
+}

--- a/bundle/EzPublishLegacyBundle.php
+++ b/bundle/EzPublishLegacyBundle.php
@@ -10,6 +10,7 @@
 namespace eZ\Bundle\EzPublishLegacyBundle;
 
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler\LegacyBundlesPass;
+use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler\LegacySessionPass;
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler\RelatedSiteAccessesCleanupPass;
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler\RoutingPass;
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Security\SSOFactory;
@@ -50,6 +51,7 @@ class EzPublishLegacyBundle extends Bundle
         $container->addCompilerPass( new TwigPass() );
         $container->addCompilerPass( new LegacyBundlesPass( $this->kernel ) );
         $container->addCompilerPass( new RoutingPass() );
+        $container->addCompilerPass( new LegacySessionPass() );
 
         /** @var \Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension $securityExtension */
         $securityExtension = $container->getExtension( 'security' );

--- a/bundle/LegacyMapper/Security.php
+++ b/bundle/LegacyMapper/Security.php
@@ -17,6 +17,7 @@ use eZ\Publish\Core\MVC\Legacy\LegacyEvents;
 use ezpWebBasedKernelHandler;
 use eZUser;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
@@ -104,7 +105,9 @@ class Security implements EventSubscriberInterface
         // IS_AUTHENTICATED_FULLY inherits from IS_AUTHENTICATED_REMEMBERED.
         // User can be either authenticated by providing credentials during current session
         // or by "remember me" if available.
-        return $this->securityContext->isGranted( 'IS_AUTHENTICATED_REMEMBERED' );
+        return
+            $this->securityContext->getToken() instanceof TokenInterface
+            && $this->securityContext->isGranted( 'IS_AUTHENTICATED_REMEMBERED' );
     }
 
     /**

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -35,6 +35,8 @@ parameters:
     ezpublish_legacy.siteaccess_mapper.class: eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\SiteAccess
     ezpublish_legacy.siteaccess_mapper.options: { fragment_path: %fragment.path% }
     ezpublish_legacy.session_mapper.class: eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\Session
+    ezpublish_legacy.session_storage_proxy.class: eZ\Publish\Core\MVC\Legacy\Session\LegacySessionStorage
+    ezpublish_legacy.session_handler_proxy.class: eZ\Publish\Core\MVC\Legacy\Session\LegacySessionProxy
     ezpublish_legacy.configuration_mapper.class: eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\Configuration
     ezpublish_legacy.configuration_mapper.options:
         imagemagick_enabled: %ezpublish.image.imagemagick.enabled%
@@ -194,6 +196,14 @@ services:
             - [setRequest, [@?request=]]
         tags:
             - { name: kernel.event_subscriber }
+
+    ezpublish_legacy.session_storage_proxy:
+        class: %ezpublish_legacy.session_storage_proxy.class%
+        arguments: [@ezpublish_legacy.kernel, ~]
+
+    ezpublish_legacy.session_handler_proxy:
+        class: %ezpublish_legacy.session_handler_proxy.class%
+        arguments: [@ezpublish_legacy.kernel, ~]
 
     ezpublish_legacy.configuration_mapper:
         class: %ezpublish_legacy.configuration_mapper.class%

--- a/bundle/Tests/LegacyMapper/SecurityTest.php
+++ b/bundle/Tests/LegacyMapper/SecurityTest.php
@@ -137,6 +137,14 @@ class SecurityTest extends PHPUnit_Framework_TestCase
             ->will( $this->returnValue( false ) );
         $this->securityContext
             ->expects( $this->once() )
+            ->method( 'getToken' )
+            ->will(
+                $this->returnValue(
+                    $this->getMock( '\Symfony\Component\Security\Core\Authentication\Token\TokenInterface' )
+                )
+            );
+        $this->securityContext
+            ->expects( $this->once() )
             ->method( 'isGranted' )
             ->with( 'IS_AUTHENTICATED_REMEMBERED' )
             ->will( $this->returnValue( false ) );
@@ -165,6 +173,14 @@ class SecurityTest extends PHPUnit_Framework_TestCase
             ->method( 'getParameter' )
             ->with( 'legacy_mode' )
             ->will( $this->returnValue( false ) );
+        $this->securityContext
+            ->expects( $this->once() )
+            ->method( 'getToken' )
+            ->will(
+                $this->returnValue(
+                    $this->getMock( '\Symfony\Component\Security\Core\Authentication\Token\TokenInterface' )
+                )
+            );
         $this->securityContext
             ->expects( $this->once() )
             ->method( 'isGranted' )

--- a/mvc/Session/LegacySessionProxy.php
+++ b/mvc/Session/LegacySessionProxy.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * This file is part of the eZ Publish LegacyBridge package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Legacy\Session;
+
+use Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy;
+use SessionHandlerInterface;
+use Closure;
+use ezpEvent;
+use eZDB;
+use eZSession;
+
+/**
+ * Session handler proxy for legacy.
+ * Ensures that appropriate legacy session events are triggered whenever needed.
+ */
+class LegacySessionProxy extends AbstractProxy implements SessionHandlerInterface
+{
+    /**
+     * @var callable
+     */
+    private $legacyKernelClosure;
+
+    /**
+     * @var SessionHandlerInterface|null
+     */
+    private $sessionHandler;
+
+    public function __construct( Closure $legacyKernelClosure, SessionHandlerInterface $sessionHandler = null )
+    {
+        $this->legacyKernelClosure = $legacyKernelClosure;
+        $this->sessionHandler = $sessionHandler;
+        $this->wrapper = true;
+        $this->saveHandlerName = ini_get( 'session.save_handler' );
+    }
+
+    /**
+     * @return \ezpKernelHandler
+     */
+    private function getLegacyKernel()
+    {
+        $closure = $this->legacyKernelClosure;
+        return $closure();
+    }
+
+    public function open( $savePath, $sessionName )
+    {
+        $return = true;
+        if ( $this->sessionHandler )
+        {
+            $return = (bool)$this->sessionHandler->open( $savePath, $sessionName );
+        }
+
+        if ( $return === true )
+        {
+            $this->active = true;
+        }
+
+        return $return;
+    }
+
+    public function close()
+    {
+        $this->active = false;
+
+        if ( $this->sessionHandler )
+        {
+            return (bool)$this->sessionHandler->close();
+        }
+
+        return true;
+    }
+
+    public function read($sessionId)
+    {
+        if ( $this->sessionHandler )
+        {
+            return (string)$this->sessionHandler->read( $sessionId );
+        }
+
+        return '';
+    }
+
+    public function write( $sessionId, $data )
+    {
+        if ( $this->sessionHandler )
+        {
+            return (bool)$this->sessionHandler->write( $sessionId, $data );
+        }
+
+        return false;
+    }
+
+    public function destroy( $sessionId )
+    {
+        $this->getLegacyKernel()->runCallback(
+            function () use ( $sessionId )
+            {
+                ezpEvent::getInstance()->notify( 'session/destroy', array( $sessionId ) );
+            },
+            false
+        );
+
+        if ( $this->sessionHandler )
+        {
+            return $this->sessionHandler->destroy( $sessionId );
+        }
+
+        return false;
+    }
+
+    public function gc( $maxlifetime )
+    {
+        $sessionHandler = $this->sessionHandler;
+        return $this->getLegacyKernel()->runCallback(
+            function () use ( $maxlifetime, $sessionHandler )
+            {
+                ezpEvent::getInstance()->notify( 'session/gc', array( $maxlifetime ) );
+                $db = eZDB::instance();
+                eZSession::triggerCallback( 'gc_pre', array( $db, $maxlifetime ) );
+
+                $success = false;
+                if ( $sessionHandler )
+                {
+                    $success = $sessionHandler->gc( $maxlifetime );
+                }
+
+                eZSession::triggerCallback( 'gc_post', array( $db, $maxlifetime ) );
+                return $success;
+            },
+            false
+        );
+    }
+}

--- a/mvc/Session/LegacySessionStorage.php
+++ b/mvc/Session/LegacySessionStorage.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * This file is part of the eZ Publish LegacyBridge package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Legacy\Session;
+
+use Symfony\Component\HttpFoundation\Session\SessionBagInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
+use ezpEvent;
+use eZSession;
+use eZDB;
+use Closure;
+
+/**
+ * Session storage proxy for legacy.
+ * Ensures that appropriate legacy session events are triggered whenever needed.
+ */
+class LegacySessionStorage implements SessionStorageInterface
+{
+    /**
+     * @var SessionStorageInterface
+     */
+    private $innerSessionStorage;
+
+    /**
+     * @var callable
+     */
+    private $legacyKernelClosure;
+
+    public function __construct( Closure $legacyKernelClosure, SessionStorageInterface $innerSessionStorage )
+    {
+        $this->innerSessionStorage = $innerSessionStorage;
+        $this->legacyKernelClosure = $legacyKernelClosure;
+    }
+
+    public function start()
+    {
+        return $this->innerSessionStorage->start();
+    }
+
+    public function isStarted()
+    {
+        return $this->innerSessionStorage->isStarted();
+    }
+
+    public function getId()
+    {
+        return $this->innerSessionStorage->getId();
+    }
+
+    public function setId( $id )
+    {
+        $this->innerSessionStorage->setId( $id );
+    }
+
+    public function getName()
+    {
+        return $this->innerSessionStorage->getName();
+    }
+
+    public function setName( $name )
+    {
+        $this->innerSessionStorage->setName( $name );
+    }
+
+    /**
+     * Ensures appropriate legacy events are sent when migrating the session.
+     *
+     * {@inheritdoc}
+     */
+    public function regenerate( $destroy = false, $lifetime = null )
+    {
+        $oldSessionId = $this->getId();
+        $success = $this->innerSessionStorage->regenerate( $destroy, $lifetime );
+        $newSessionId = $this->getId();
+
+        if ( $success )
+        {
+            $kernelClosure = $this->legacyKernelClosure;
+            $kernelClosure()->runCallback(
+                function () use ( $oldSessionId, $newSessionId )
+                {
+                    ezpEvent::getInstance()->notify( 'session/regenerate', array( $oldSessionId, $newSessionId ) );
+                    $db = eZDB::instance();
+                    $escOldKey = $db->escapeString( $oldSessionId );
+                    $escNewKey = $db->escapeString( $newSessionId );
+                    $escUserID = $db->escapeString( eZSession::userID() );
+                    eZSession::triggerCallback( 'regenerate_pre', array( $db, $escNewKey, $escOldKey, $escUserID ) );
+                    eZSession::triggerCallback( 'regenerate_post', array( $db, $escNewKey, $escOldKey, $escUserID ) );
+                },
+                false
+            );
+        }
+
+        return $success;
+    }
+
+    public function save()
+    {
+        $this->innerSessionStorage->save();
+    }
+
+    /**
+     * Clear all session data in memory.
+     */
+    public function clear()
+    {
+        $this->innerSessionStorage->clear();
+    }
+
+    public function getBag( $name )
+    {
+        return $this->innerSessionStorage->getBag( $name );
+    }
+
+    public function registerBag( SessionBagInterface $bag )
+    {
+        $this->innerSessionStorage->registerBag( $bag );
+    }
+
+    public function getMetadataBag()
+    {
+        return $this->innerSessionStorage->getMetadataBag();
+    }
+}


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23953
> https://jira.ez.no/browse/EZP-23904

As of 5.3, authentication is completely managed through Symfony. One side effect is that legacy session events are not triggered any more (either via `ezpEvent` or `eZSession::triggerCallback()`), and thus listeners won't be executed. This is because it is now entirely up to Symfony to deal with the session, including session migration after authentication.
**Concrete illustration of this regression :** When using the legacy shop module, items in the shopping basket are lost after logging in.
In short, when the session is migrated after the user has been authenticated, the basket table, storing each entry per session ID, won't be updated at that time, resulting the loss of the basket for current user.

This PR introduces proxies for session storage and session save handler. They use legacy callbacks to trigger the appropriate events, just like what is done in legacy session handlers.