### PR TITLE
Changed ezpublish-kernel requirement to ~6.0@alpha

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "minimum-stability": "stable",
     "require": {
         "ezsystems/ezpublish-legacy": ">=2014.11",
-        "ezsystems/ezpublish-kernel": "dev-master"
+        "ezsystems/ezpublish-kernel": "~6.0@alpha"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "0.*",


### PR DESCRIPTION
PR to follow-up on a Skype discussion.

One argument was that this would make QA testing of master more difficult. It doesn't really apply here imho, since it's not a "real requirement" but a "must be there" requirement (e.g. yes, LegacyBridge does depend on ezpublish-kernel, and requires at least 6.0.0@alpha1, but it won't install it itself.

Furthermore, non-root composer.json file can't require a dev branch. It must be done from the root composer.json.