### PR TITLE
Fix EZP-23710: ezpublish:legacy:assets_install --relative fails on windows

### DIFF
--- a/bundle/Command/LegacyWrapperInstallCommand.php
+++ b/bundle/Command/LegacyWrapperInstallCommand.php
@@ -85,7 +85,10 @@ EOT
             {
                 $filesystem->mkdir( $targetDir, 0777 );
                 // We use a custom iterator to ignore VCS files
+                $currentDir = getcwd();
+                chdir( realpath( $targetArg ) );
                 $filesystem->mirror( $originDir, $targetDir, Finder::create()->in( $originDir ) );
+                chdir( $currentDir );
             }
         }
 


### PR DESCRIPTION
Fixed by changing current working directory to the base of the relative directory before doing Finder::create()

https://jira.ez.no/browse/EZP-23710