### PR TITLE
Fix EZP-24135: Output buffer gets cleared after legacy call

### DIFF
--- a/mvc/Kernel.php
+++ b/mvc/Kernel.php
@@ -68,16 +68,6 @@ class Kernel extends ezpKernel
         $this->setUseExceptions( true );
     }
 
-    /**
-     * Checks if LegacyKernel has already been instantiated.
-     *
-     * @return bool
-     */
-    public static function hasInstance()
-    {
-        return static::$instance !== null;
-    }
-
     public static function resetInstance()
     {
         static::$instance = null;


### PR DESCRIPTION
Moved hasInstance() method from \eZ\Publish\Core\MVC\Legacy\Kernel to ezpKernel
ref https://github.com/ezsystems/ezpublish-legacy/pull/1150

https://jira.ez.no/browse/EZP-24135