### PR TITLE
Fix EZP-24171: "You cannot create a service ("request") of an inactive scope ("request")." while running cache:clear command

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -250,6 +250,7 @@ services:
             - @ezpublish.siteaccess
         tags:
             - { name: kernel.cache_clearer }
+        lazy: true
 
     ezpublish_legacy.switchable_http_cache_purger:
         class: %ezpublish_legacy.switchable_http_cache_purger.class%


### PR DESCRIPTION
Due to missing lazy loading of `ezpublish_legacy.legacy_cache_purger`, legacy kernel (which is a dependency of said service) is being built with web handler instead of the CLI one, before `LegacyKernelListener::onConsoleCommand` has a chance to run and set the CLI legacy handler.

Due to this, when running `php ezpublish/console cache:clear`, there's a following exception (stack trace is included):

```bash
eddie@abyss: ~/www/ezplatform $ php ezpublish/console cache:clear -v
Clearing the cache for the dev environment with debug true


                                                                             
  [Symfony\Component\DependencyInjection\Exception\InactiveScopeException]   
  You cannot create a service ("request") of an inactive scope ("request").  
                                                                             


Exception trace:
 () at /var/www/html/ezplatform/ezpublish/cache/dev/ezpublishDevDebugProjectContainer.php:17813
 ezpublishDevDebugProjectContainer->getRequestService() at /var/www/html/ezplatform/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Container.php:326
 Symfony\Component\DependencyInjection\Container->get() at /var/www/html/ezplatform/vendor/ezsystems/legacy-bridge/mvc/Kernel/Loader.php:152
 eZ\Publish\Core\MVC\Legacy\Kernel\Loader->eZ\Publish\Core\MVC\Legacy\Kernel\{closure}() at /var/www/html/ezplatform/vendor/ezsystems/legacy-bridge/mvc/Kernel/Loader.php:112
 eZ\Publish\Core\MVC\Legacy\Kernel\Loader->eZ\Publish\Core\MVC\Legacy\Kernel\{closure}() at /var/www/html/ezplatform/vendor/ezsystems/legacy-bridge/bundle/Cache/LegacyCachePurger.php:56
 eZ\Bundle\EzPublishLegacyBundle\Cache\LegacyCachePurger->getLegacyKernel() at /var/www/html/ezplatform/vendor/ezsystems/legacy-bridge/bundle/Cache/LegacyCachePurger.php:66
 eZ\Bundle\EzPublishLegacyBundle\Cache\LegacyCachePurger->clear() at /var/www/html/ezplatform/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/CacheClearer/ChainCacheClearer.php:42
 Symfony\Component\HttpKernel\CacheClearer\ChainCacheClearer->clear() at /var/www/html/ezplatform/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php:70
 Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand->execute() at /var/www/html/ezplatform/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:257
 Symfony\Component\Console\Command\Command->run() at /var/www/html/ezplatform/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:882
 Symfony\Component\Console\Application->doRunCommand() at /var/www/html/ezplatform/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:195
 Symfony\Component\Console\Application->doRun() at /var/www/html/ezplatform/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:96
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /var/www/html/ezplatform/vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/Console/Application.php:41
 eZ\Bundle\EzPublishCoreBundle\Console\Application->doRun() at /var/www/html/ezplatform/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:126
 Symfony\Component\Console\Application->run() at /var/www/html/ezplatform/ezpublish/console:27


cache:clear [--no-warmup] [--no-optional-warmers]


eddie@abyss: ~/www/ezplatform $
```