### PR TITLE
Fix EZP-23725: Wrong path_identification_string when editing in frontend siteaccess using PathPrefix and RootNode

### DIFF
--- a/bundle/LegacyMapper/Configuration.php
+++ b/bundle/LegacyMapper/Configuration.php
@@ -310,7 +310,6 @@ class Configuration extends ContainerAware implements EventSubscriberInterface
             'logfile.ini/AccessLogFileSettings/PathPrefix'  => $pathPrefix,
             'site.ini/SiteSettings/IndexPage'               => $indexPage !== null ? $indexPage : "/content/view/full/$rootLocationId/",
             'site.ini/SiteSettings/DefaultPage'             => $defaultPage !== null ? $defaultPage : "/content/view/full/$rootLocationId/",
-            'content.ini/NodeSettings/RootNode'             => $rootLocationId,
         );
     }
 }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23725

Alternative of https://github.com/ezsystems/ezpublish-legacy/pull/1148, https://github.com/ezsystems/ezpublish-legacy/pull/1140 and https://github.com/ezsystems/ezpublish-legacy/pull/1145

Root cause of this issue is that `RootNode` is wrongly injected from LegacyBundle when working in multisite, as it's has no purpose in that regard.

Note that patch from https://github.com/ezsystems/ezpublish-legacy/pull/1140 needs to be reverted (it will be once this PR is merged).

Tested and working as expected.