### PR TITLE
Fix EZP-24053: Preview locks content object, and cause version edit conflict

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -168,6 +168,7 @@ services:
             - @ezpublish.api.service.content
             - @ezpublish.api.service.location
             - @security.context
+            - @ezpublish.content_preview_helper
             - @?form.csrf_provider
 
     ezpublish_legacy.router:

--- a/bundle/Resources/config/templating.yml
+++ b/bundle/Resources/config/templating.yml
@@ -41,6 +41,7 @@ services:
         tags:
             - {name: ezpublish_legacy.templating.converter, for: %ezpublish.api.content.class%}
             - {name: ezpublish_legacy.templating.converter, for: %ezpublish.api.location.class%}
+            - {name: ezpublish_legacy.templating.converter, for: %ezpublish.api.version.class%}
 
     ezpublish_legacy.templating.pageparts_converter:
         class: %ezpublish_legacy.templating.pageparts_converter.class%

--- a/mvc/Templating/Converter/ApiContentConverter.php
+++ b/mvc/Templating/Converter/ApiContentConverter.php
@@ -11,8 +11,10 @@ namespace eZ\Publish\Core\MVC\Legacy\Templating\Converter;
 
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZContentObject;
 use eZContentObjectTreeNode;
+use eZContentObjectVersion;
 
 class ApiContentConverter implements MultipleObjectConverter
 {
@@ -68,6 +70,10 @@ class ApiContentConverter implements MultipleObjectConverter
                 {
                     return eZContentObjectTreeNode::fetch( $object->id );
                 }
+                else if ( $object instanceof VersionInfo )
+                {
+                    return eZContentObjectVersion::fetchVersion( $object->versionNo, $object->getContentInfo()->id );
+                }
             },
             false,
             false
@@ -119,6 +125,10 @@ class ApiContentConverter implements MultipleObjectConverter
                     else if ( $apiObject instanceof Location )
                     {
                         $convertedObjects[$alias] = eZContentObjectTreeNode::fetch( $apiObject->id );
+                    }
+                    else if ( $apiObject instanceof VersionInfo )
+                    {
+                        $convertedObjects[$alias] = eZContentObjectVersion::fetchVersion( $apiObject->versionNo, $apiObject->getContentInfo()->id );
                     }
                 }
 


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24053
> https://jira.ez.no/browse/EZP-24052

LegacyBridge part. See also https://github.com/ezsystems/ezpublish-kernel/pull/1216 .
This PR ensures that legacy website toolbar is loaded with appropriate template when in preview.