### PR TITLE
EZP-24278: integrated Legacy REST API in Kernel

### DIFF
--- a/bundle/Controller/LegacyRestController.php
+++ b/bundle/Controller/LegacyRestController.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * File containing the LegacyRestController class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\Controller;
+
+use eZ\Publish\Core\MVC\Symfony\Controller\Controller;
+use eZ\Publish\Core\MVC\Legacy\Kernel\Loader;
+use ezpKernelRest;
+use Symfony\Component\HttpFoundation\Response;
+
+class LegacyRestController extends Controller
+{
+    /**
+     * @var \ezpKernelHandler
+     */
+    protected $restKernel;
+
+    public function __construct( \Closure $restKernelHandler, Loader $legacyKernelFactory, array $options = array() )
+    {
+        $kernelClosure = $legacyKernelFactory->buildLegacyKernel( $restKernelHandler );
+        $this->restKernel = $kernelClosure();
+    }
+
+    /**
+     *
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function restAction()
+    {
+        $this->restKernel->run();
+
+        $result = ezpKernelRest::getResponse();
+        if ( $result === null )
+        {
+            throw new Exception( "Rest Kernel run failed" );
+        }
+
+        return new Response(
+            $result->getContent(),
+            $result->hasAttribute( 'statusCode' ) ? $result->getAttribute( 'statusCode' ) : 200,
+            $result->hasAttribute( 'headers' ) ? $result->getAttribute('headers') : array()
+        );
+    }
+}

--- a/bundle/Resources/config/routing.yml
+++ b/bundle/Resources/config/routing.yml
@@ -19,3 +19,10 @@ _ezpublishLegacyLogout:
     path: /user/logout
     defaults:
         _controller: ezpublish_legacy.controller:logoutAction
+
+_ezpublishLegacyRest:
+    path: /api/{provider}/v1/{path}
+    defaults:
+        _controller: ezpublish_legacy.rest.controller:restAction
+    requirements:
+        path: .*

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -13,9 +13,11 @@ parameters:
     ezpublish_legacy.kernel_handler.class: ezpKernelHandler
     ezpublish_legacy.kernel_handler.web.class: ezpKernelWeb
     ezpublish_legacy.kernel_handler.treemenu.class: ezpKernelTreeMenu
+    ezpublish_legacy.kernel_handler.rest.class: ezpKernelRest
 
     ezpublish_legacy.controller.class: eZ\Bundle\EzPublishLegacyBundle\Controller\LegacyKernelController
     ezpublish_legacy.response_manager.class: eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager
+    ezpublish_legacy.rest.controller.class: eZ\Bundle\EzPublishLegacyBundle\Controller\LegacyRestController
     ezpublish_legacy.treemenu.controller.class: eZ\Bundle\EzPublishLegacyBundle\Controller\LegacyTreeMenuController
     ezpublish_legacy.treemenu.controller.options: {}
     ezpublish_legacy.setup.controller.class: eZ\Bundle\EzPublishLegacyBundle\Controller\LegacySetupController
@@ -98,6 +100,12 @@ services:
         calls:
             - [setContainer, [@service_container]]
 
+    ezpublish_legacy.rest.kernel_handler:
+        class: %ezpublish_legacy.kernel_handler.rest.class%
+        factory_service: ezpublish_legacy.kernel.lazy_loader
+        factory_method: buildLegacyKernelHandlerRest
+        arguments: [%ezpublish_legacy.kernel_handler.rest.class%]
+
     ezpublish_legacy.kernel_handler.web:
         class: %ezpublish_legacy.kernel_handler.class%
         factory_service: ezpublish_legacy.kernel.lazy_loader
@@ -139,6 +147,14 @@ services:
             - @ezpublish_legacy.kernel_handler.treemenu
             - @ezpublish_legacy.kernel.lazy_loader
             - %ezpublish_legacy.treemenu.controller.options%
+        parent: ezpublish.controller.base
+        scope: request
+
+    ezpublish_legacy.rest.controller:
+        class: %ezpublish_legacy.rest.controller.class%
+        arguments:
+            - @ezpublish_legacy.rest.kernel_handler
+            - @ezpublish_legacy.kernel.lazy_loader
         parent: ezpublish.controller.base
         scope: request
 

--- a/bundle/Rest/ResponseWriter.php
+++ b/bundle/Rest/ResponseWriter.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishLegacyBundle\Rest;
+
+use ezcMvcRequest;
+use ezcMvcResponse;
+use ezcMvcResultCache;
+use ezcMvcResultContent;
+use ezcMvcResultStatusObject;
+use ezpKernelRest;
+use ezpKernelResult;
+use ezpRestHttpResponseWriter;
+use Symfony\Component\HttpFoundation\Response;
+
+class ResponseWriter extends ezpRestHttpResponseWriter
+{
+    public function handleResponse()
+    {
+        // process all headers
+        $this->processStandardHeaders();
+        if ( $this->response->cache instanceof ezcMvcResultCache )
+        {
+            $this->processCacheHeaders();
+        }
+        if ( $this->response->content instanceof ezcMvcResultContent )
+        {
+            $this->processContentHeaders();
+        }
+
+        // process the status headers through objects
+        if ( !$this->response->status instanceof ezcMvcResultStatusObject )
+        {
+            $responseCode = 200;
+        }
+        else
+        {
+            $responseCode = $this->response->status->code;
+        }
+
+        // automatically add content-length header
+        $this->headers['Content-Length'] = strlen( $this->response->body );
+
+        ezpKernelRest::setResponse(
+            new ezpKernelResult( $this->response->body, array( 'headers' => $this->headers, 'statusCode' => $responseCode ) )
+        );
+    }
+}


### PR DESCRIPTION
> Fixes http://jira.ez.no/browse/EZP-24278
> Requires ezsystems/ezpublish-legacy#1168

This PR adds the required elements (kernel loader, route, controller...) to run the V1 REST API through the new stack.

It overrides the ezcResponseWriter used by MVC tools in the kernel loader in order to go build a proper Response out of it. The usage of a static method is arguable...

## TODO
- [ ] Rewrite rules in ezpublish-community + ezplatform (legacy-bridge) to let REST V1 requests go through the regular index.php