### PR TITLE
Fix EZP-24367: Token error with remember me activated in Legacy and Symfony

### DIFF
--- a/bundle/DependencyInjection/Compiler/RememberMeListenerPass.php
+++ b/bundle/DependencyInjection/Compiler/RememberMeListenerPass.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of the eZ LegacyBridge package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class RememberMeListenerPass implements CompilerPassInterface
+{
+    public function process( ContainerBuilder $container )
+    {
+        if ( !$container->hasDefinition( 'security.authentication.listener.rememberme' ) )
+        {
+            return;
+        }
+
+        $listenerDef = $container->findDefinition( 'security.authentication.listener.rememberme' );
+        $listenerDef->addMethodCall( 'setConfigResolver', array( new Reference( 'ezpublish.config.resolver' ) ) );
+    }
+}

--- a/bundle/EventListener/RequestListener.php
+++ b/bundle/EventListener/RequestListener.php
@@ -80,7 +80,6 @@ class RequestListener implements EventSubscriberInterface
             if ( $token instanceof TokenInterface )
             {
                 $token->setUser( new User( $apiUser ) );
-                $token->setAuthenticated( true );
             }
         }
         catch ( NotFoundException $e )

--- a/bundle/EzPublishLegacyBundle.php
+++ b/bundle/EzPublishLegacyBundle.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Bundle\EzPublishLegacyBundle;
 
+use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler\RememberMeListenerPass;
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler\LegacyBundlesPass;
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler\LegacySessionPass;
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler\RelatedSiteAccessesCleanupPass;
@@ -52,6 +53,7 @@ class EzPublishLegacyBundle extends Bundle
         $container->addCompilerPass( new LegacyBundlesPass( $this->kernel ) );
         $container->addCompilerPass( new RoutingPass() );
         $container->addCompilerPass( new LegacySessionPass() );
+        $container->addCompilerPass( new RememberMeListenerPass() );
 
         /** @var \Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension $securityExtension */
         $securityExtension = $container->getExtension( 'security' );

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -8,6 +8,7 @@ parameters:
     # Core overrides
     router.class: eZ\Bundle\EzPublishLegacyBundle\Routing\DefaultRouter
     ezpublish.security.login_listener.class: eZ\Bundle\EzPublishLegacyBundle\Security\SecurityListener
+    security.authentication.listener.rememberme.class: eZ\Bundle\EzPublishLegacyBundle\Security\RememberMeListener
 
     ezpublish_legacy.kernel.lazy_loader.class: eZ\Publish\Core\MVC\Legacy\Kernel\Loader
     ezpublish_legacy.kernel_handler.class: ezpKernelHandler

--- a/bundle/Security/RememberMeListener.php
+++ b/bundle/Security/RememberMeListener.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * This file is part of the eZ LegacyBridge package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\Security;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Security\Http\Firewall\RememberMeListener as BaseRememberMeListener;
+
+class RememberMeListener extends BaseRememberMeListener
+{
+    /**
+     * @var ConfigResolverInterface
+     */
+    private $configResolver;
+
+    /**
+     * @param ConfigResolverInterface $configResolver
+     */
+    public function setConfigResolver( ConfigResolverInterface $configResolver )
+    {
+        $this->configResolver = $configResolver;
+    }
+
+    public function handle( GetResponseEvent $event )
+    {
+        // In legacy_mode, "remember me" must be delegated to legacy kernel.
+        if ( $this->configResolver->getParameter( 'legacy_mode' ) )
+        {
+            return;
+        }
+
+        parent::handle( $event );
+    }
+}

--- a/bundle/Tests/EventListener/RequestListenerTest.php
+++ b/bundle/Tests/EventListener/RequestListenerTest.php
@@ -108,10 +108,6 @@ class RequestListenerTest extends PHPUnit_Framework_TestCase
             ->expects( $this->once() )
             ->method( 'setUser' )
             ->with( $this->isInstanceOf( 'eZ\Publish\Core\MVC\Symfony\Security\User' ) );
-        $token
-            ->expects( $this->once() )
-            ->method( 'setAuthenticated' )
-            ->with( true );
 
         $event = new GetResponseEvent(
             $this->getMock( 'Symfony\Component\HttpKernel\HttpKernelInterface' ),


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24367

RememberMeToken doesn't accept to be manually set authenticated, which is done by legacy mode. This is not needed as all authentication/authorization process is fully done by legacy in that case.

This PR removes the `setAuthenticated()` call on the token. Note that in the profiler toolbar, username will appear in yellow (not authenticated). This is perfectly safe as security is fully handled by legacy kernel.
Further more, this PR also ensures that RememberMeListener is never called when in legacy mode.