### PR TITLE
Fix EZP-24463: Preview will fail with remember me activated in Legacy and Symfony

### DIFF
--- a/bundle/EventListener/RequestListener.php
+++ b/bundle/EventListener/RequestListener.php
@@ -12,6 +12,7 @@ namespace eZ\Bundle\EzPublishLegacyBundle\EventListener;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Legacy\Security\LegacyToken;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -80,6 +81,11 @@ class RequestListener implements EventSubscriberInterface
             if ( $token instanceof TokenInterface )
             {
                 $token->setUser( new User( $apiUser ) );
+                // Don't embed if we already have a LegacyToken, to avoid nested session storage.
+                if ( !$token instanceof LegacyToken )
+                {
+                    $this->tokenStorage->setToken( new LegacyToken( $token ) );
+                }
             }
         }
         catch ( NotFoundException $e )

--- a/mvc/Security/LegacyToken.php
+++ b/mvc/Security/LegacyToken.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * This file is part of the eZ LegacyBridge package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Legacy\Security;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * Security token for legacy mode usage.
+ * Wraps the real token and ensures it is always marked as authenticated, authentication being done by legacy kernel.
+ *
+ * DO NOT USE OUTSIDE OF LEGACY MODE.
+ */
+class LegacyToken implements TokenInterface
+{
+    /**
+     * @var TokenInterface
+     */
+    private $innerToken;
+
+    public function __construct( TokenInterface $innerToken )
+    {
+        $this->innerToken = $innerToken;
+    }
+
+    public function serialize()
+    {
+        return serialize( array( $this->innerToken ) );
+    }
+
+    public function unserialize( $serialized )
+    {
+        list( $this->innerToken ) = unserialize( $serialized );
+    }
+
+    public function __toString()
+    {
+        return $this->innerToken->__toString();
+    }
+
+    public function getRoles()
+    {
+        return $this->innerToken->getRoles();
+    }
+
+    public function getCredentials()
+    {
+        return $this->innerToken->getCredentials();
+    }
+
+    public function getUser()
+    {
+        return $this->innerToken->getUser();
+    }
+
+    public function setUser( $user )
+    {
+        $this->innerToken->setUser( $user );
+    }
+
+    public function getUsername()
+    {
+        return $this->innerToken->getUsername();
+    }
+
+    public function isAuthenticated()
+    {
+        return true;
+    }
+
+    public function setAuthenticated( $isAuthenticated )
+    {
+        $this->innerToken->setAuthenticated( $isAuthenticated );
+    }
+
+    public function eraseCredentials()
+    {
+        $this->innerToken->eraseCredentials();
+    }
+
+    public function getAttributes()
+    {
+        return $this->innerToken->getAttributes();
+    }
+
+    public function setAttributes( array $attributes )
+    {
+        $this->innerToken->setAttributes( $attributes );
+    }
+
+    public function hasAttribute( $name )
+    {
+        return $this->innerToken->hasAttribute( $name );
+    }
+
+    public function getAttribute( $name )
+    {
+        return $this->innerToken->getAttribute( $name );
+    }
+
+    public function setAttribute( $name, $value )
+    {
+        $this->innerToken->setAttribute( $name, $value );
+    }
+}


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24463

See [EZP-24367](https://jira.ez.no/browse/EZP-24367) and https://github.com/ezsystems/LegacyBridge/pull/26

Previous PR removed `$token->setAuthenticated( true )` as this is not permitted with some tokens like RememberMeToken (hence the exception before).
However, not being authenticated has a side effect. The AuthorizationChecker will indeed ensure by default that current token is authenticated before checking authorization. And as preview checks if
current user is granted permission in the PreviewController, permission is denied and the system tries to redirect to the login page.

This PR introduces `LegacyToken` which decorates current token. It will always say that it's authenticated. Note that there is no security risk as authentication has already been made by the legacy kernel.