### PR TITLE
Fix the Installation and the Usage of the LegacyBridge

### DIFF
--- a/mvc/Kernel/Loader.php
+++ b/mvc/Kernel/Loader.php
@@ -146,6 +146,11 @@ class Loader extends ContainerAware
         $container = $this->container;
         $that = $this;
 
+        if ( PHP_SAPI == 'cli' )
+        {
+            return $this->buildLegacyKernelHandlerCLI();
+        }
+
         return function () use ( $legacyRootDir, $webrootDir, $container, $defaultLegacyOptions, $webHandlerClass, $uriHelper, $eventDispatcher, $that )
         {
             if ( !$that->getWebHandler() )
@@ -226,7 +231,7 @@ class Loader extends ContainerAware
                 $that->setCLIHandler(
                     new CLIHandler( $legacyParameters->all(), $container->get( 'ezpublish.siteaccess' ), $container )
                 );
-                chdir( $webrootDir );
+                chdir( $webrootDir ."/../" );
             }
 
             return $that->getCLIHandler();


### PR DESCRIPTION
Not sure about the quality of this fix, but it was not easy to find ;-)

Apparently the _buildLegacyKernelHandlerWeb_ function is called by the Symfony command (through a Listener) and then if we are in CLI we got: 2 errors:

*First*:
```
> Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::clearCache
[Symfony\Component\DependencyInjection\Exception\InactiveScopeException]
  You cannot create a service ("request") of an inactive scope ("request”).
```

Pretty logical: https://github.com/ezsystems/LegacyBridge/blob/master/mvc/Kernel/Loader.php#L157
> The request doesn't exist in CLI.

*Second*:
```
$ php ezpublish/console assets:install --symlink --relative -vvv
  [InvalidArgumentException]
  The target directory "web" does not exist.
```

> Same case here, it's a path issue.

The code below is needed for this 2 issues
```php
if ( PHP_SAPI == 'cli' )
{
     return $this->buildLegacyKernelHandlerCLI();
}
```
But we needed to go back in the good directory instead of the Web Directory (CLI)

ping @andrerom @lolautruche 

++
