### PR TITLE
Fix restoring working directory when building legacy CLI kernel handler

### DIFF
--- a/mvc/Kernel/Loader.php
+++ b/mvc/Kernel/Loader.php
@@ -215,6 +215,7 @@ class Loader extends ContainerAware
         {
             if ( !$that->getCLIHandler() )
             {
+                $currentDir = getcwd();
                 chdir( $legacyRootDir );
 
                 $legacyParameters = new ParameterBag( $container->getParameter( 'ezpublish_legacy.kernel_handler.cli.options' ) );
@@ -226,7 +227,8 @@ class Loader extends ContainerAware
                 $that->setCLIHandler(
                     new CLIHandler( $legacyParameters->all(), $container->get( 'ezpublish.siteaccess' ), $container )
                 );
-                chdir( $webrootDir );
+
+                chdir( $currentDir );
             }
 
             return $that->getCLIHandler();

--- a/mvc/Kernel/Loader.php
+++ b/mvc/Kernel/Loader.php
@@ -206,12 +206,11 @@ class Loader extends ContainerAware
     public function buildLegacyKernelHandlerCLI()
     {
         $legacyRootDir = $this->legacyRootDir;
-        $webrootDir = $this->webrootDir;
         $eventDispatcher = $this->eventDispatcher;
         $container = $this->container;
         $that = $this;
 
-        return function () use ( $legacyRootDir, $webrootDir, $container, $eventDispatcher, $that )
+        return function () use ( $legacyRootDir, $container, $eventDispatcher, $that )
         {
             if ( !$that->getCLIHandler() )
             {


### PR DESCRIPTION
After merging #31, and associated PR in `ezsystems/ezpublish-kernel`, I get an error when running `assets:install` command:

```
eddie@abyss: /var/www/html/netgensite $ php ezpublish/console assets:install --symlink --relative -v
                                              
  [InvalidArgumentException]                  
  The target directory "web" does not exist.  
                                              
Exception trace:
 () at /var/www/html/netgensite/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php:74
 Symfony\Bundle\FrameworkBundle\Command\AssetsInstallCommand->execute() at /var/www/html/netgensite/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:259
 Symfony\Component\Console\Command\Command->run() at /var/www/html/netgensite/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:886
 Symfony\Component\Console\Application->doRunCommand() at /var/www/html/netgensite/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:195
 Symfony\Component\Console\Application->doRun() at /var/www/html/netgensite/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:96
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /var/www/html/netgensite/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:126
 Symfony\Component\Console\Application->run() at /var/www/html/netgensite/ezpublish/console:27


assets:install [--symlink] [--relative] [--] [<target>]
```

This fixes the issue by making sure that the previously used working directory is restored after building CLI kernel handler, instead of restoring to web root (`web/`).