### PR TITLE
EZP-24691: Fixed regression when resetting the kernel and it is not yet installed/configured

### DIFF
--- a/mvc/Kernel/Loader.php
+++ b/mvc/Kernel/Loader.php
@@ -313,12 +313,15 @@ class Loader extends ContainerAware
      */
     public function resetKernel()
     {
-        /** @var \Closure $kernelClosure */
-        $kernelClosure = $this->container->get('ezpublish_legacy.kernel');
-        $this->eventDispatcher->dispatch(
-            LegacyEvents::PRE_RESET_LEGACY_KERNEL,
-            new PreResetLegacyKernelEvent($kernelClosure())
-        );
+        // Reset the kernel only if it has been initialized.
+        if (LegacyKernel::hasInstance()) {
+            /** @var \Closure $kernelClosure */
+            $kernelClosure = $this->container->get('ezpublish_legacy.kernel');
+            $this->eventDispatcher->dispatch(
+                LegacyEvents::PRE_RESET_LEGACY_KERNEL,
+                new PreResetLegacyKernelEvent($kernelClosure())
+            );
+        }
 
         LegacyKernel::resetInstance();
         $this->webHandler = null;


### PR DESCRIPTION
Fixes regression introduced in #31 
When you have a clean install (wizard not run yet), a PDO exception is thrown because the legacy kernel loader tries to load the kernel to reset it.

With this patch the kernel will be reset only if it is already initialized.