### PR TITLE
Fix EZP-24761: PHP fatal error redeclaring eZUpdateDebugSettings

### DIFF
--- a/mvc/Kernel/Loader.php
+++ b/mvc/Kernel/Loader.php
@@ -210,6 +210,9 @@ class Loader extends ContainerAware
                 $currentDir = getcwd();
                 chdir($legacyRootDir);
 
+                // require global functions before cli instance.
+                require_once 'kernel/private/classes/global_functions.php';
+
                 $legacyParameters = new ParameterBag($container->getParameter('ezpublish_legacy.kernel_handler.cli.options'));
                 if ($that->getBuildEventsEnabled()) {
                     $eventDispatcher->dispatch(LegacyEvents::PRE_BUILD_LEGACY_KERNEL, new PreBuildKernelEvent($legacyParameters));


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24761

##### Problem:
legacy eZScript is being instantiated before kernel, which causes a redeclaration of `eZUpdateDebugSettings()`
( see https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/classes/ezscript.php#L1223 )

##### Solution:
As ezpKernelWeb already requires global_functions manually, apply the same solution here 
(ref: https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/private/classes/ezpkernelweb.php#L145 )
