### PR TITLE
EZP-24869: Refactor view providers to match the new interfaces

### DIFF
--- a/bundle/Resources/config/view.yml
+++ b/bundle/Resources/config/view.yml
@@ -18,7 +18,7 @@ services:
         class: %ezpublish_legacy.content_view_provider.class%
         parent: ezpublish_legacy.view_provider
         tags:
-            - {name: ezpublish.content_view_provider, priority: -255}
+            - {name: ezpublish.view_provider, type: 'eZ\Publish\Core\MVC\Symfony\View\ContentView', priority: -255}
 
     ezpublish_legacy.location_view_provider:
         class: %ezpublish_legacy.location_view_provider.class%
@@ -27,7 +27,9 @@ services:
             # Injecting the request, in non strict mode ("=") avoiding this service to be forced in request scope.
             - [setRequestStack, [@request_stack]]
         tags:
-            - {name: ezpublish.location_view_provider, priority: -255}
+            # Location view provider must have priority higher than content view provider to be able
+            # to match the location first, in case it exists in the view
+            - {name: ezpublish.view_provider, type: 'eZ\Publish\Core\MVC\Symfony\View\ContentView', priority: -250}
 
     ezpublish_legacy.block_view_provider:
         class: %ezpublish_legacy.block_view_provider.class%
@@ -35,7 +37,7 @@ services:
         calls:
             - [setPageService, [@ezpublish.fieldType.ezpage.pageService]]
         tags:
-            - {name: ezpublish.block_view_provider, priority: -255}
+            - {name: ezpublish.view_provider, type: 'eZ\Publish\Core\MVC\Symfony\View\BlockView', priority: -255}
 
     ezpublish_legacy.view_decorator.twig:
         class: %ezpublish_legacy.view_decorator.twig.class%

--- a/mvc/View/Provider/Block.php
+++ b/mvc/View/Provider/Block.php
@@ -9,17 +9,16 @@
 namespace eZ\Publish\Core\MVC\Legacy\View\Provider;
 
 use eZ\Publish\Core\MVC\Legacy\View\Provider;
-use eZ\Publish\Core\MVC\Symfony\View\Provider\Block as BlockViewProviderInterface;
-use eZ\Publish\Core\FieldType\Page\Parts\Block as PageBlock;
+use eZ\Publish\Core\MVC\Symfony\View\BlockView;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use eZ\Publish\Core\MVC\Symfony\View\ViewProvider;
 use eZ\Publish\Core\MVC\Legacy\Templating\Adapter\BlockAdapter;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
-use eZ\Publish\Core\MVC\Symfony\View\ViewProviderMatcher;
-use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\Core\FieldType\Page\PageService;
 use eZTemplate;
 use ezpEvent;
 
-class Block extends Provider implements BlockViewProviderInterface
+class Block extends Provider implements ViewProvider
 {
     /**
      * @var \eZ\Publish\Core\FieldType\Page\PageService
@@ -35,14 +34,20 @@ class Block extends Provider implements BlockViewProviderInterface
     }
 
     /**
-     * Returns a ContentView object corresponding to $block, or null if not applicable.
+     * Returns a ContentView object corresponding to block found within $view, or null if not applicable.
      *
-     * @param \eZ\Publish\Core\FieldType\Page\Parts\Block $block
+     * @param \eZ\Publish\Core\MVC\Symfony\View\View $view
      *
      * @return \eZ\Publish\Core\MVC\Symfony\View\ContentView
      */
-    public function getView(PageBlock $block)
+    public function getView(View $view)
     {
+        if (!$view instanceof BlockView) {
+            return null;
+        }
+
+        $block = $view->getBlock();
+
         $legacyKernel = $this->getLegacyKernel();
         $legacyBlockClosure = function (array $params) use ($block, $legacyKernel) {
             return $legacyKernel->runCallback(
@@ -88,13 +93,5 @@ class Block extends Provider implements BlockViewProviderInterface
         };
 
         return new ContentView($legacyBlockClosure);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function match(ViewProviderMatcher $matcher, ValueObject $valueObject)
-    {
-        return true;
     }
 }

--- a/mvc/View/Provider/Content.php
+++ b/mvc/View/Provider/Content.php
@@ -10,27 +10,31 @@ namespace eZ\Publish\Core\MVC\Legacy\View\Provider;
 
 use eZ\Publish\Core\FieldType\XmlText\Converter\EmbedToHtml5;
 use eZ\Publish\Core\MVC\Legacy\View\Provider;
-use eZ\Publish\Core\MVC\Symfony\View\Provider\Content as ContentViewProviderInterface;
-use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use eZ\Publish\Core\MVC\Symfony\View\ViewProvider;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
-use eZ\Publish\Core\MVC\Symfony\View\ViewProviderMatcher;
-use eZ\Publish\API\Repository\Values\ValueObject;
 use eZContentObject;
 use eZTemplate;
 use ezpEvent;
 
-class Content extends Provider implements ContentViewProviderInterface
+class Content extends Provider implements ViewProvider
 {
     /**
-     * Returns a ContentView object corresponding to $contentInfo, or void if not applicable.
+     * Returns a ContentView object corresponding to content info found within $view, or void if not applicable.
      *
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     * @param string $viewType Variation of display for your content
+     * @param \eZ\Publish\Core\MVC\Symfony\View\View $view
      *
      * @return \eZ\Publish\Core\MVC\Symfony\View\ContentView|void
      */
-    public function getView(ContentInfo $contentInfo, $viewType)
+    public function getView(View $view)
     {
+        if (!$view instanceof ContentView) {
+            return null;
+        }
+
+        $viewType = $view->getViewType();
+        $contentInfo = $view->getContent()->contentInfo;
+
         $legacyKernel = $this->getLegacyKernel();
         $legacyContentClosure = function (array $params) use ($contentInfo, $viewType, $legacyKernel) {
             return $legacyKernel->runCallback(
@@ -107,6 +111,7 @@ class Content extends Provider implements ContentViewProviderInterface
                 false
             );
         };
+
         $this->decorator->setContentView(
             new ContentView($legacyContentClosure)
         );
@@ -169,20 +174,5 @@ class Content extends Provider implements ContentViewProviderInterface
         }
 
         return $parameters;
-    }
-
-    /**
-     * Checks if $valueObject matches the $matcher's rules.
-     *
-     * @param \eZ\Publish\Core\MVC\Symfony\View\ViewProviderMatcher $matcher
-     * @param \eZ\Publish\API\Repository\Values\ValueObject $valueObject
-     *
-     * @throws \InvalidArgumentException If $valueObject is not of expected sub-type.
-     *
-     * @return bool
-     */
-    public function match(ViewProviderMatcher $matcher, ValueObject $valueObject)
-    {
-        return true;
     }
 }

--- a/mvc/View/TwigContentViewLayoutDecorator.php
+++ b/mvc/View/TwigContentViewLayoutDecorator.php
@@ -9,12 +9,14 @@
 namespace eZ\Publish\Core\MVC\Legacy\View;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
-use eZ\Publish\Core\MVC\Symfony\View\ContentViewInterface;
+use eZ\Publish\Core\MVC\Symfony\View\View;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Twig_Environment;
 
-class TwigContentViewLayoutDecorator implements ContentViewInterface
+class TwigContentViewLayoutDecorator implements View
 {
     /**
      * @var \eZ\Publish\Core\MVC\Symfony\View\ContentView
@@ -26,17 +28,35 @@ class TwigContentViewLayoutDecorator implements ContentViewInterface
      */
     protected $twig;
 
+    /**
+     * @var array
+     */
     protected $options;
 
     /**
      * @var array
      */
-    protected $configHash;
+    protected $configHash = array();
 
     /**
      * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
      */
-    private $configResolver;
+    protected $configResolver;
+
+    /**
+     * @var string
+     */
+    protected $viewType = 'full';
+
+    /**
+     * @var \Symfony\Component\HttpKernel\Controller\ControllerReference
+     */
+    protected $controllerReference;
+
+    /**
+     * @var \Symfony\Component\HttpFoundation\Response
+     */
+    protected $response;
 
     public function __construct(Twig_Environment $twig, array $options, ConfigResolverInterface $configResolver)
     {
@@ -190,5 +210,48 @@ EOT;
     public function getConfigHash()
     {
         return $this->configHash;
+    }
+
+    public function setViewType($viewType)
+    {
+        $this->viewType = $viewType;
+    }
+
+    public function getViewType()
+    {
+        return $this->viewType;
+    }
+
+    public function setControllerReference(ControllerReference $controllerReference)
+    {
+        $this->controllerReference = $controllerReference;
+    }
+
+    /**
+     * @return ControllerReference
+     */
+    public function getControllerReference()
+    {
+        return $this->controllerReference;
+    }
+
+    /**
+     * Sets a pre-configured Response that will be used to render the View.
+     *
+     * @param Response $response
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * Returns the pre-configured Response.
+     *
+     * @return \Symfony\Component\HttpFoundation\Response|null
+     */
+    public function getResponse()
+    {
+        return $this->response;
     }
 }


### PR DESCRIPTION
This PR refactors legacy view providers to use the new interafaces which work with View objects.

Depends on https://github.com/ezsystems/ezpublish-kernel/pull/1454

This refactor also fixes issue with fallback to legacy view providers detailed in https://github.com/ezsystems/ezpublish-kernel/pull/1451. However, that issue should still be considered for 5.4, since fallback to legacy view providers in 5.4 will remain broken.