### PR TITLE
Fix compatibility with Twig 2.0 by not extending deprecated Twig_Loader_String

### DIFF
--- a/mvc/Templating/Tests/Twig/LoaderStringTest.php
+++ b/mvc/Templating/Tests/Twig/LoaderStringTest.php
@@ -13,6 +13,24 @@ use PHPUnit_Framework_TestCase;
 
 class LoaderStringTest extends PHPUnit_Framework_TestCase
 {
+    public function testGetSource()
+    {
+        $loaderString = new LoaderString();
+        $this->assertSame('foo', $loaderString->getSource('foo'));
+    }
+
+    public function testGetCacheKey()
+    {
+        $loaderString = new LoaderString();
+        $this->assertSame('foo', $loaderString->getCacheKey('foo'));
+    }
+
+    public function testIsFresh()
+    {
+        $loaderString = new LoaderString();
+        $this->assertSame(true, $loaderString->isFresh('foo', time()));
+    }
+
     /**
      * @dataProvider existsProvider
      */

--- a/mvc/Templating/Twig/LoaderString.php
+++ b/mvc/Templating/Twig/LoaderString.php
@@ -8,15 +8,40 @@
  */
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Twig;
 
-use Twig_Loader_String;
+use Twig_LoaderInterface;
+use Twig_ExistsLoaderInterface;
 
 /**
  * This loader is supposed to directly load templates as a string, not from FS.
  *
  * {@inheritdoc}
  */
-class LoaderString extends Twig_Loader_String
+class LoaderString implements Twig_LoaderInterface, Twig_ExistsLoaderInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function getSource($name)
+    {
+        return $name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCacheKey($name)
+    {
+        return $name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isFresh($name, $time)
+    {
+        return true;
+    }
+
     /**
      * Returns true if $name is a string template, false if $name is a template name (which should be loaded by Twig_Loader_Filesystem.
      *


### PR DESCRIPTION
`Twig_Loader_String` and eZ variant `LoaderString` serve the purpose of loading legacy templates and it works fine.

Since `Twig_Loader_String` is deprecated and will be removed in Twig 2.0, this simply makes sure that our loader does not extend the original one, instead implementing required methods by itself.

Since the methods are fairly simple, and `exists()` was overriden anyhow, and also considering that this is after all *legacy* bridge, i think this is the most reasonable way to get the bundle to be compatible with Twig 2.0.

Tested manually with dev-master of `twig/twig` package.