### PR TITLE
Implement Twig_Extension_InitRuntimeInterface in Twig extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "minimum-stability": "stable",
     "require": {
         "ezsystems/ezpublish-legacy": ">=2014.11",
-        "ezsystems/ezpublish-kernel": "~6.0@dev"
+        "ezsystems/ezpublish-kernel": "~6.0@dev",
+        "twig/twig": "^1.23 | ^2.0"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "0.*",

--- a/mvc/Templating/Twig/Extension/LegacyExtension.php
+++ b/mvc/Templating/Twig/Extension/LegacyExtension.php
@@ -14,11 +14,12 @@ use eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine;
 use Twig_Extension;
 use Twig_SimpleFunction;
 use Twig_Environment;
+use Twig_Extension_InitRuntimeInterface;
 
 /**
  * Twig extension for eZ Publish legacy.
  */
-class LegacyExtension extends Twig_Extension
+class LegacyExtension extends Twig_Extension implements Twig_Extension_InitRuntimeInterface
 {
     /**
      * @var \eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine


### PR DESCRIPTION
https://github.com/twigphp/Twig/pull/1886 deprecated `Twig_ExtensionInterface::initRuntime()` method which legacy Twig extension uses. and it will be removed in Twig 2.0.

To make the bundle compatible with Twig 2.0, this PR makes the extension implement `Twig_Extension_InitRuntimeInterface` interface which is available in latest Twig 1.23 version.