### PR TITLE
Fix tests that error out

### DIFF
--- a/bundle/Tests/Controller/PreviewControllerTest.php
+++ b/bundle/Tests/Controller/PreviewControllerTest.php
@@ -37,7 +37,8 @@ class PreviewControllerTest extends BasePreviewControllerTest
             $this->httpKernel,
             $this->previewHelper,
             $this->authorizationChecker,
-            $this->locationProvider
+            $this->locationProvider,
+            $this->controllerChecker
         );
         $controller->setConfigResolver($this->configResolver);
 


### PR DESCRIPTION
Adds a missing constructor argument in test.

Depends on: https://github.com/ezsystems/ezpublish-kernel/pull/1506