### PR TITLE
Adjust view provider priorities to come before the ones in kernel that provide default templates

### DIFF
--- a/bundle/Resources/config/view.yml
+++ b/bundle/Resources/config/view.yml
@@ -18,7 +18,7 @@ services:
         class: %ezpublish_legacy.content_view_provider.class%
         parent: ezpublish_legacy.view_provider
         tags:
-            - {name: ezpublish.view_provider, type: 'eZ\Publish\Core\MVC\Symfony\View\ContentView', priority: -255}
+            - {name: ezpublish.view_provider, type: 'eZ\Publish\Core\MVC\Symfony\View\ContentView', priority: 4}
 
     ezpublish_legacy.location_view_provider:
         class: %ezpublish_legacy.location_view_provider.class%
@@ -29,7 +29,7 @@ services:
         tags:
             # Location view provider must have priority higher than content view provider to be able
             # to match the location first, in case it exists in the view
-            - {name: ezpublish.view_provider, type: 'eZ\Publish\Core\MVC\Symfony\View\ContentView', priority: -250}
+            - {name: ezpublish.view_provider, type: 'eZ\Publish\Core\MVC\Symfony\View\ContentView', priority: 5}
 
     ezpublish_legacy.block_view_provider:
         class: %ezpublish_legacy.block_view_provider.class%


### PR DESCRIPTION
Now that eZ kernel always provides the default templates (https://github.com/ezsystems/ezpublish-kernel/pull/1496), this will never execute, so raising priorities to make it work again.