### PR TITLE
Remove Symfony 2.8 deprecation notices

### DIFF
--- a/bundle/EventListener/LegacyKernelListener.php
+++ b/bundle/EventListener/LegacyKernelListener.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\MVC\Legacy\Event\PreResetLegacyKernelEvent;
 use eZINI;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
@@ -23,8 +23,10 @@ use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
  * Resets eZINI when the Legacy Kernel is reset.
  * Resets legacy kernel handler when used in a command.
  */
-class LegacyKernelListener extends ContainerAware implements EventSubscriberInterface
+class LegacyKernelListener implements EventSubscriberInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * @var EventDispatcherInterface
      */

--- a/bundle/LegacyMapper/Configuration.php
+++ b/bundle/LegacyMapper/Configuration.php
@@ -18,15 +18,17 @@ use eZ\Publish\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use ezpEvent;
 use ezxFormToken;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use RuntimeException;
 
 /**
  * Maps configuration parameters to the legacy parameters.
  */
-class Configuration extends ContainerAware implements EventSubscriberInterface
+class Configuration implements EventSubscriberInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
      */

--- a/bundle/LegacyMapper/SiteAccess.php
+++ b/bundle/LegacyMapper/SiteAccess.php
@@ -12,14 +12,16 @@ use eZ\Publish\Core\MVC\Legacy\LegacyEvents;
 use eZ\Publish\Core\MVC\Legacy\Event\PreBuildKernelWebHandlerEvent;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\CompoundInterface;
 use eZSiteAccess;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Maps the SiteAccess object to the legacy parameters.
  */
-class SiteAccess extends ContainerAware implements EventSubscriberInterface
+class SiteAccess implements EventSubscriberInterface
 {
+    use ContainerAwareTrait;
+
     protected $options = array();
 
     public function __construct(array $options = array())

--- a/bundle/Resources/config/debug.yml
+++ b/bundle/Resources/config/debug.yml
@@ -4,7 +4,7 @@ parameters:
 services:
     ezpublish_legacy.debug.templates_collector:
         class: %ezpublish_legacy.debug.templates_collector.class%
-        arguments: [@ezpublish_legacy.kernel]
+        arguments: ["@ezpublish_legacy.kernel"]
         tags:
             -
                 name: ezpublish_data_collector

--- a/bundle/Resources/config/fieldtype_services.yml
+++ b/bundle/Resources/config/fieldtype_services.yml
@@ -6,6 +6,6 @@ services:
     ezpublish_legacy.image_alias.cleaner:
         class: %ezpublish_legacy.image_alias.cleaner.class%
         arguments:
-            - @ezpublish.image_alias.imagine.alias_cleaner
-            - @ezpublish.core.io.image_fieldtype.legacy_url_redecorator
+            - "@ezpublish.image_alias.imagine.alias_cleaner"
+            - "@ezpublish.core.io.image_fieldtype.legacy_url_redecorator"
         lazy: true

--- a/bundle/Resources/config/security.yml
+++ b/bundle/Resources/config/security.yml
@@ -11,7 +11,7 @@ services:
 
     ezpublish_legacy.security_mapper:
         class: %ezpublish_legacy.security_mapper.class%
-        arguments: [@ezpublish.api.repository, @ezpublish.config.resolver, @security.token_storage, @security.authorization_checker]
+        arguments: ["@ezpublish.api.repository", "@ezpublish.config.resolver", "@security.token_storage", "@security.authorization_checker"]
         tags:
             - { name: kernel.event_subscriber }
 
@@ -19,11 +19,11 @@ services:
         class: %ezpublish_legacy.security.sso_firewall_listener.class%
         abstract: true
         arguments:
-            - @security.token_storage
-            - @security.authentication.manager
+            - "@security.token_storage"
+            - "@security.authentication.manager"
             - ~     # Will be replaced at compile time by the security factory to be the right user provider
-            - @?logger
-            - @?event_dispatcher
+            - "@?logger"
+            - "@?event_dispatcher"
         calls:
-            - [setLegacyKernelClosure, [@ezpublish_legacy.kernel]]
-            - [setUserService, [@ezpublish.api.service.user]]
+            - [setLegacyKernelClosure, ["@ezpublish_legacy.kernel"]]
+            - [setUserService, ["@ezpublish.api.service.user"]]

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -87,18 +87,18 @@ services:
     ezpublish_legacy.kernel.lazy:
         class: Closure
         factory: ["@ezpublish_legacy.kernel.lazy_loader", buildLegacyKernel]
-        arguments: [@ezpublish_legacy.kernel_handler]
+        arguments: ["@ezpublish_legacy.kernel_handler"]
 
     ezpublish_legacy.kernel.lazy_loader:
         class: %ezpublish_legacy.kernel.lazy_loader.class%
         arguments:
             - %ezpublish_legacy.root_dir%
             - %webroot_dir%
-            - @event_dispatcher
-            - @ezpublish_legacy.uri_helper
-            - @?logger
+            - "@event_dispatcher"
+            - "@ezpublish_legacy.uri_helper"
+            - "@?logger"
         calls:
-            - [setContainer, [@service_container]]
+            - [setContainer, ["@service_container"]]
 
     ezpublish_legacy.rest.kernel_handler:
         class: %ezpublish_legacy.kernel_handler.rest.class%
@@ -123,47 +123,47 @@ services:
 
     ezpublish_legacy.response_manager:
         class: %ezpublish_legacy.response_manager.class%
-        arguments: [@templating, @ezpublish.config.resolver]
+        arguments: ["@templating", "@ezpublish.config.resolver"]
 
     ezpublish_legacy.controller:
         class: %ezpublish_legacy.controller.class%
         arguments:
-            - @ezpublish_legacy.kernel
-            - @ezpublish.config.resolver
-            - @ezpublish_legacy.uri_helper
-            - @ezpublish_legacy.response_manager
-            - @ezpublish_legacy.templating.legacy_helper
-            - @router
+            - "@ezpublish_legacy.kernel"
+            - "@ezpublish.config.resolver"
+            - "@ezpublish_legacy.uri_helper"
+            - "@ezpublish_legacy.response_manager"
+            - "@ezpublish_legacy.templating.legacy_helper"
+            - "@router"
 
     ezpublish_legacy.treemenu.controller:
         class: %ezpublish_legacy.treemenu.controller.class%
         arguments:
-            - @ezpublish_legacy.kernel_handler.treemenu
-            - @ezpublish_legacy.kernel.lazy_loader
+            - "@ezpublish_legacy.kernel_handler.treemenu"
+            - "@ezpublish_legacy.kernel.lazy_loader"
             - %ezpublish_legacy.treemenu.controller.options%
         parent: ezpublish.controller.base
 
     ezpublish_legacy.rest.controller:
         class: %ezpublish_legacy.rest.controller.class%
         arguments:
-            - @ezpublish_legacy.rest.kernel_handler
-            - @ezpublish_legacy.kernel.lazy_loader
+            - "@ezpublish_legacy.rest.kernel_handler"
+            - "@ezpublish_legacy.kernel.lazy_loader"
         parent: ezpublish.controller.base
 
     ezpublish_legacy.setup.controller:
         class: %ezpublish_legacy.setup.controller.class%
         parent: ezpublish.controller.base
         arguments:
-            - @ezpublish_legacy.kernel
-            - @ezpublish_legacy.config.resolver
-            - @ezpublish_legacy.persistence_cache_purger
-            - @ezpublish_legacy.kernel.lazy_loader
+            - "@ezpublish_legacy.kernel"
+            - "@ezpublish_legacy.config.resolver"
+            - "@ezpublish_legacy.persistence_cache_purger"
+            - "@ezpublish_legacy.kernel.lazy_loader"
 
     ezpublish_legacy.preview.controller:
         class: %ezpublish_legacy.preview.controller.class%
         parent: ezpublish.controller.content.preview.core
         calls:
-            - [setConfigResolver, [@ezpublish.config.resolver]]
+            - [setConfigResolver, ["@ezpublish.config.resolver"]]
 
     ezpublish.controller.content.preview:
         alias: ezpublish_legacy.preview.controller
@@ -172,16 +172,16 @@ services:
         class: %ezpublish_legacy.website_toolbar.controller.class%
         parent: ezpublish.controller.base
         arguments:
-            - @templating.engine.eztpl
-            - @ezpublish.api.service.content
-            - @ezpublish.api.service.location
-            - @security.authorization_checker
-            - @ezpublish.content_preview_helper
-            - @?form.csrf_provider
+            - "@templating.engine.eztpl"
+            - "@ezpublish.api.service.content"
+            - "@ezpublish.api.service.location"
+            - "@security.authorization_checker"
+            - "@ezpublish.content_preview_helper"
+            - "@?form.csrf_provider"
 
     ezpublish_legacy.router:
         class: %ezpublish_legacy.router.class%
-        arguments: [@ezpublish_legacy.url_generator, @?request_context, @?logger]
+        arguments: ["@ezpublish_legacy.url_generator", "@?request_context", "@?logger"]
         tags:
             - {name: router, priority: -255}
         lazy: true
@@ -191,7 +191,7 @@ services:
 
     ezpublish_legacy.url_generator:
         class: %ezpublish_legacy.url_generator.class%
-        arguments: [@ezpublish_legacy.kernel]
+        arguments: ["@ezpublish_legacy.kernel"]
         parent: ezpublish.url_generator.base
 
     ezpublish_legacy.siteaccess_mapper:
@@ -199,52 +199,52 @@ services:
         arguments:
             - %ezpublish_legacy.siteaccess_mapper.options%
         calls:
-            - [setContainer, [@service_container]]
+            - [setContainer, ["@service_container"]]
         tags:
             - { name: kernel.event_subscriber }
 
     ezpublish_legacy.session_mapper:
         class: %ezpublish_legacy.session_mapper.class%
-        arguments: [@session.storage, %ezpublish.session.attribute_bag.storage_key%, @?session]
+        arguments: ["@session.storage", %ezpublish.session.attribute_bag.storage_key%, "@?session"]
         calls:
-            - [setRequestStack, [@request_stack]]
+            - [setRequestStack, ["@request_stack"]]
         tags:
             - { name: kernel.event_subscriber }
 
     ezpublish_legacy.session_storage_proxy:
         class: %ezpublish_legacy.session_storage_proxy.class%
-        arguments: [@ezpublish_legacy.kernel, ~]
+        arguments: ["@ezpublish_legacy.kernel", ~]
 
     ezpublish_legacy.session_handler_proxy:
         class: %ezpublish_legacy.session_handler_proxy.class%
-        arguments: [@ezpublish_legacy.kernel, ~]
+        arguments: ["@ezpublish_legacy.kernel", ~]
 
     ezpublish_legacy.configuration_mapper:
         class: %ezpublish_legacy.configuration_mapper.class%
         arguments:
-            - @ezpublish.config.resolver.core
-            - @ezpublish_legacy.switchable_http_cache_purger
-            - @ezpublish_legacy.persistence_cache_purger
-            - @ezpublish.urlalias_generator
-            - @ezpublish.api.storage_engine.legacy.dbhandler
-            - @ezpublish_legacy.image_alias.cleaner
+            - "@ezpublish.config.resolver.core"
+            - "@ezpublish_legacy.switchable_http_cache_purger"
+            - "@ezpublish_legacy.persistence_cache_purger"
+            - "@ezpublish.urlalias_generator"
+            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+            - "@ezpublish_legacy.image_alias.cleaner"
             - %ezpublish_legacy.configuration_mapper.options%
         calls:
-            - [setContainer, [@service_container]]
+            - [setContainer, ["@service_container"]]
         tags:
             - { name: kernel.event_subscriber }
 
     ezpublish_legacy.legacy_bundles_mapper:
         class: %ezpublish_legacy.legacy_bundles_mapper.class%
         arguments:
-            - @ezpublish.config.resolver.core
+            - "@ezpublish.config.resolver.core"
             - { extensions: %ezpublish_legacy.legacy_bundles_extensions% }
         tags:
             - { name: kernel.event_subscriber }
 
     ezpublish_legacy.persistence_cache_purger:
         class: %ezpublish_legacy.persistence_cache_purger.class%
-        arguments: [@ezpublish.cache_pool.spi.cache.decorator, @ezpublish.spi.persistence.cache.locationHandler, @logger]
+        arguments: ["@ezpublish.cache_pool.spi.cache.decorator", "@ezpublish.spi.persistence.cache.locationHandler", "@logger"]
         tags:
             - { name: kernel.cache_clearer }
         lazy: true
@@ -252,44 +252,44 @@ services:
     ezpublish_legacy.legacy_cache_purger:
         class: %ezpublish_legacy.legacy_cache_purger.class%
         arguments:
-            - @ezpublish_legacy.kernel
-            - @ezpublish_legacy.configuration_mapper
-            - @filesystem
+            - "@ezpublish_legacy.kernel"
+            - "@ezpublish_legacy.configuration_mapper"
+            - "@filesystem"
             - %ezpublish_legacy.root_dir%
-            - @ezpublish.siteaccess
+            - "@ezpublish.siteaccess"
         tags:
             - { name: kernel.cache_clearer }
         lazy: true
 
     ezpublish_legacy.switchable_http_cache_purger:
         class: %ezpublish_legacy.switchable_http_cache_purger.class%
-        arguments: [@ezpublish.http_cache.purger]
+        arguments: ["@ezpublish.http_cache.purger"]
 
     ezpublish_legacy.content_exception_handler:
         class: %ezpublish_legacy.content_exception_handler.class%
-        arguments: [@ezpublish_legacy.content_view_provider, @ezpublish_legacy.location_view_provider, @?logger]
+        arguments: ["@ezpublish_legacy.content_view_provider", "@ezpublish_legacy.location_view_provider", "@?logger"]
         tags:
             - { name: kernel.event_subscriber }
 
     ezpublish_legacy.config.resolver:
         class: %ezpublish_legacy.config.resolver.class%
-        arguments: [@ezpublish_legacy.kernel, %ezpublish_legacy.config.default_scope%]
+        arguments: ["@ezpublish_legacy.kernel", %ezpublish_legacy.config.default_scope%]
         lazy: true
         tags:
             - { name: ezpublish.config.resolver, priority: -255 }
 
     ezpublish_legacy.setup_wizard.configuration_converter:
         class: %ezpublish_legacy.setup_wizard.configuration_converter.class%
-        arguments: [@ezpublish_legacy.config.resolver, @ezpublish_legacy.kernel, %ezpublish_legacy.setup_wizard.supported_packages%]
+        arguments: ["@ezpublish_legacy.config.resolver", "@ezpublish_legacy.kernel", %ezpublish_legacy.setup_wizard.supported_packages%]
 
     ezpublish_legacy.setup_wizard.configuration_dumper:
         class: %ezpublish_legacy.setup_wizard.configuration_dumper.class%
         arguments:
-            - @filesystem
+            - "@filesystem"
             - %ezpublish_legacy.setup_wizard.configuration_dumper.environments%
             - %kernel.root_dir%
             - %kernel.cache_dir%
-            - @ezpublish_legacy.webconfigurator
+            - "@ezpublish_legacy.webconfigurator"
 
     # eZ alias for sensio.distribution.webconfigurator to make it available despite Bundle being disabled in prod env
     # uses factory to make sure steps are injected only when service is needed
@@ -305,7 +305,7 @@ services:
     # Image alias generator using legacy
     ezpublish_legacy.fieldType.ezimage.variation_service:
         class: %ezpublish_legacy.fieldType.ezimage.variation_service.class%
-        arguments: [@ezpublish_legacy.kernel]
+        arguments: ["@ezpublish_legacy.kernel"]
 
     ezpublish_legacy.rest_listener:
         class: %ezpublish_legacy.rest_listener.class%
@@ -315,7 +315,7 @@ services:
 
     ezpublish_legacy.request_listener:
         class: %ezpublish_legacy.request_listener.class%
-        arguments: [@ezpublish.config.resolver, @ezpublish.api.repository, @security.token_storage]
+        arguments: ["@ezpublish.config.resolver", "@ezpublish.api.repository", "@security.token_storage"]
         tags:
             - { name: kernel.event_subscriber }
 
@@ -326,15 +326,15 @@ services:
 
     ezpublish_legacy.config_scope_listener:
         class: %ezpublish_legacy.config_scope_listener.class%
-        arguments: [@ezpublish_legacy.kernel.lazy_loader]
+        arguments: ["@ezpublish_legacy.kernel.lazy_loader"]
         tags:
             - { name: kernel.event_subscriber }
 
     ezpublish_legacy.legacy_kernel_listener:
         class: %ezpublish_legacy.legacy_kernel_listener.class%
-        arguments: [@event_dispatcher]
+        arguments: ["@event_dispatcher"]
         calls:
-            - [setContainer, [@service_container]]
+            - [setContainer, ["@service_container"]]
         tags:
             - { name: kernel.event_subscriber }
 
@@ -344,7 +344,7 @@ services:
     ezpublish_legacy.setup_listener:
         class: %ezpublish_legacy.setup_listener.class%
         arguments:
-            - @router
+            - "@router"
             - %ezpublish.siteaccess.default%
         tags:
             - { name: kernel.event_subscriber }

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -142,7 +142,6 @@ services:
             - @ezpublish_legacy.kernel.lazy_loader
             - %ezpublish_legacy.treemenu.controller.options%
         parent: ezpublish.controller.base
-        scope: request
 
     ezpublish_legacy.rest.controller:
         class: %ezpublish_legacy.rest.controller.class%
@@ -150,7 +149,6 @@ services:
             - @ezpublish_legacy.rest.kernel_handler
             - @ezpublish_legacy.kernel.lazy_loader
         parent: ezpublish.controller.base
-        scope: request
 
     ezpublish_legacy.setup.controller:
         class: %ezpublish_legacy.setup.controller.class%

--- a/bundle/Resources/config/slot.yml
+++ b/bundle/Resources/config/slot.yml
@@ -33,9 +33,9 @@ services:
     ezpublish_legacy.signalslot.base:
         class: eZ\Publish\Core\MVC\Legacy\SignalSlot\AbstractLegacySlot
         arguments:
-            - @ezpublish_legacy.kernel
-            - @ezpublish_legacy.persistence_cache_purger
-            - @ezpublish_legacy.switchable_http_cache_purger
+            - "@ezpublish_legacy.kernel"
+            - "@ezpublish_legacy.persistence_cache_purger"
+            - "@ezpublish_legacy.switchable_http_cache_purger"
 
     ezpublish_legacy.signalslot.assign_section:
         class: %ezpublish_legacy.signalslot.assign_section.class%

--- a/bundle/Resources/config/templating.yml
+++ b/bundle/Resources/config/templating.yml
@@ -19,8 +19,8 @@ services:
     ezpublish_legacy.twig.extension:
         class: %ezpublish_legacy.twig.extension.class%
         arguments:
-            - @templating.engine.eztpl
-            - @ezpublish_legacy.templating.legacy_helper
+            - "@templating.engine.eztpl"
+            - "@ezpublish_legacy.templating.legacy_helper"
             - %ezpublish_legacy.twig.extension.template.js%
             - %ezpublish_legacy.twig.extension.template.css%
         tags:
@@ -31,14 +31,14 @@ services:
 
     ezpublish_legacy.templating.delegating_converter:
         class: %ezpublish_legacy.templating.delegating_converter.class%
-        arguments: [@ezpublish_legacy.templating.generic_converter]
+        arguments: ["@ezpublish_legacy.templating.generic_converter"]
 
     ezpublish_legacy.templating.object_converter:
         alias: ezpublish_legacy.templating.delegating_converter
 
     ezpublish_legacy.templating.api_content_converter:
         class: %ezpublish_legacy.templating.api_content_converter.class%
-        arguments: [@ezpublish_legacy.kernel]
+        arguments: ["@ezpublish_legacy.kernel"]
         tags:
             - {name: ezpublish_legacy.templating.converter, for: %ezpublish.api.content.class%}
             - {name: ezpublish_legacy.templating.converter, for: %ezpublish.api.location.class%}
@@ -52,13 +52,13 @@ services:
 
     ezpublish_legacy.templating.legacy_helper:
         class: %ezpublish_legacy.templating.legacy_helper.class%
-        arguments: [@ezpublish_legacy.kernel]
+        arguments: ["@ezpublish_legacy.kernel"]
 
     ezpublish.templating.global_helper.legacy:
         class: %ezpublish.templating.global_helper.legacy.class%
         parent: ezpublish.templating.global_helper.core
         calls:
-            - [setLegacyHelper, [@ezpublish_legacy.templating.legacy_helper]]
+            - [setLegacyHelper, ["@ezpublish_legacy.templating.legacy_helper"]]
 
     # Overriding core helper
     ezpublish.templating.global_helper:
@@ -66,7 +66,7 @@ services:
 
     templating.engine.eztpl:
         class: %templating.engine.eztpl.class%
-        arguments: [@ezpublish_legacy.kernel, @ezpublish_legacy.templating.object_converter]
+        arguments: ["@ezpublish_legacy.kernel", "@ezpublish_legacy.templating.object_converter"]
 
     assetic.eztpl_formula_loader:
         class: %assetic.eztpl_formula_loader.class%

--- a/bundle/Resources/config/view.yml
+++ b/bundle/Resources/config/view.yml
@@ -11,7 +11,7 @@ parameters:
 services:
     ezpublish_legacy.view_provider:
         class: %ezpublish_legacy.view_provider.class%
-        arguments: [@ezpublish_legacy.kernel, @ezpublish_legacy.view_decorator, @ezpublish_legacy.templating.legacy_helper, @?logger]
+        arguments: ["@ezpublish_legacy.kernel", "@ezpublish_legacy.view_decorator", "@ezpublish_legacy.templating.legacy_helper", "@?logger"]
         abstract: true
 
     ezpublish_legacy.content_view_provider:
@@ -25,7 +25,7 @@ services:
         parent: ezpublish_legacy.view_provider
         calls:
             # Injecting the request, in non strict mode ("=") avoiding this service to be forced in request scope.
-            - [setRequestStack, [@request_stack]]
+            - [setRequestStack, ["@request_stack"]]
         tags:
             # Location view provider must have priority higher than content view provider to be able
             # to match the location first, in case it exists in the view
@@ -35,13 +35,13 @@ services:
         class: %ezpublish_legacy.block_view_provider.class%
         parent: ezpublish_legacy.view_provider
         calls:
-            - [setPageService, [@ezpublish.fieldType.ezpage.pageService]]
+            - [setPageService, ["@ezpublish.fieldType.ezpage.pageService"]]
         tags:
             - {name: ezpublish.view_provider, type: 'eZ\Publish\Core\MVC\Symfony\View\BlockView', priority: -255}
 
     ezpublish_legacy.view_decorator.twig:
         class: %ezpublish_legacy.view_decorator.twig.class%
-        arguments: [@twig, %ezpublish_legacy.view_decorator.options%, @ezpublish.config.resolver]
+        arguments: ["@twig", %ezpublish_legacy.view_decorator.options%, "@ezpublish.config.resolver"]
 
     ezpublish_legacy.view_decorator:
         alias: ezpublish_legacy.view_decorator.twig

--- a/mvc/Kernel/Loader.php
+++ b/mvc/Kernel/Loader.php
@@ -16,7 +16,7 @@ use eZ\Publish\Core\MVC\Legacy\Event\PreBuildKernelWebHandlerEvent;
 use eZ\Publish\Core\MVC\Legacy\Event\PreBuildKernelEvent;
 use ezpKernelHandler;
 use ezpKernelRest;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -24,8 +24,10 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 /**
  * Legacy kernel loader.
  */
-class Loader extends ContainerAware
+class Loader
 {
+    use ContainerAwareTrait;
+
     /**
      * @var string Absolute path to the legacy root directory (eZPublish 4 install dir)
      */


### PR DESCRIPTION
This removes three Symfony 2.8 deprecation notices:

1) Notice about extending deprecated `ContainerAwareInterface`
2) Notice about using `scope` parameter in service definitions
3) Notice about using deprecated non quoted service references that start with `@`