### PR TITLE
Adjust block view provider priority

### DIFF
--- a/bundle/Resources/config/view.yml
+++ b/bundle/Resources/config/view.yml
@@ -37,7 +37,7 @@ services:
         calls:
             - [setPageService, ["@ezpublish.fieldType.ezpage.pageService"]]
         tags:
-            - {name: ezpublish.view_provider, type: 'eZ\Publish\Core\MVC\Symfony\View\BlockView', priority: -255}
+            - {name: ezpublish.view_provider, type: 'eZ\Publish\Core\MVC\Symfony\View\BlockView', priority: 5}
 
     ezpublish_legacy.view_decorator.twig:
         class: %ezpublish_legacy.view_decorator.twig.class%


### PR DESCRIPTION
This PR adjusts block view provider priority to come before the one in kernel that provides default templates.

Now that eZ kernel always provides the default templates (ezsystems/ezpublish-kernel#1496), this will never execute, so raising priority to make it work again.

This PR is continuation of https://github.com/ezsystems/LegacyBridge/pull/44. It should've been included there.