### PR TITLE
Remove uneeded resetting of ezpublish_legacy.kernel alias

### DIFF
--- a/mvc/Kernel/Loader.php
+++ b/mvc/Kernel/Loader.php
@@ -330,7 +330,6 @@ class Loader
         $this->cliHandler = null;
         $this->restHandler = null;
 
-        $this->container->set('ezpublish_legacy.kernel', null);
         $this->container->set('ezpublish_legacy.kernel.lazy', null);
         $this->container->set('ezpublish_legacy.kernel_handler.web', null);
         $this->container->set('ezpublish_legacy.kernel_handler.cli', null);


### PR DESCRIPTION
With Symfony 2.7.10, the following error occurs when running legacy scripts through `ezpublish:legacy:script` wrapper:

```
eddie@abyss [~/www/netgensite] ( ± master ● ● ) $ php app/console ezpublish:legacy:script bin/php/ezpgenerateautoloads.php
Running script 'bin/php/ezpgenerateautoloads.php' in eZ Publish legacy context
                                                                                                                                                                                 
  [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]                                                                                                     
  You have requested a non-existent service "ezpublish_legacy.kernel". Did you mean one of these: "ezpublish_legacy.router", "ezpublish_legacy.kernel.lazy_loader", "ezpublish_  
  legacy.kernel_handler", "ezpublish_legacy.kernel_handler.cli", "ezpublish_legacy.kernel_handler.web"?                                                                          
                                                                                                                                                                                 
ezpublish:legacy:script [--legacy-help] [--] <script>
```

The fix is quite simple:

In Symfony 2.7.0 - 2.7.9, line removed here did nothing, since `ezpublish_legacy.kernel`
is an alias and `Container::set` never did anything with aliases.

In Symfony 2.7.10, setting an alias to a new value basically converts the
alias definition to service definition, meaning that `ezpublish_legacy.kernel`
will not point to `ezpublish_legacy.kernel.lazy` any more, thus making the alias
invalid next time `ezpublish_legacy.kernel.lazy` is rebuilt.

See https://github.com/symfony/symfony/issues/16461 for details

Manual tests only were performed. Unit tests passed locally.