### PR TITLE
Fixed SensioDistributionBundle compatibility

### DIFF
--- a/bundle/Composer/ScriptHandler.php
+++ b/bundle/Composer/ScriptHandler.php
@@ -9,7 +9,7 @@
 namespace eZ\Bundle\EzPublishLegacyBundle\Composer;
 
 use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler as DistributionBundleScriptHandler;
-use Composer\Script\CommandEvent;
+use Composer\Script\Event as CommandEvent;
 
 class ScriptHandler extends DistributionBundleScriptHandler
 {


### PR DESCRIPTION
`ScriptHandler::installAssets()` signature has changed to accept
`Composer\Script\Event` instead of `Composer\Script\CommandEvent` which
was deprecated.

See https://github.com/sensiolabs/SensioDistributionBundle/pull/265