### PR TITLE
Fix EZP-25739: utf-8 URIs break siteaccess match / ezurl()

### DIFF
--- a/bundle/LegacyMapper/SiteAccess.php
+++ b/bundle/LegacyMapper/SiteAccess.php
@@ -83,7 +83,7 @@ class SiteAccess implements EventSubscriberInterface
         $pathinfo = str_replace($request->attributes->get('viewParametersString'), '', $request->getPathInfo());
         $semanticPathinfo = $request->attributes->get('semanticPathinfo', $pathinfo);
         if ($pathinfo != $semanticPathinfo) {
-            $aPathinfo = explode('/', substr($pathinfo, 1));
+            $aPathinfo = explode('/', substr(rawurldecode($pathinfo), 1));
             $aSemanticPathinfo = explode('/', substr($semanticPathinfo, 1));
             $uriPart = array_diff($aPathinfo, $aSemanticPathinfo, $this->getFragmentPathItems());
         }

--- a/bundle/Tests/SiteAccess/LegacyMapperTest.php
+++ b/bundle/Tests/SiteAccess/LegacyMapperTest.php
@@ -60,6 +60,16 @@ class LegacyMapperTest extends LegacyBasedTestCase
                 ),
             ),
             array(
+                '/some%C3%BCtf/path',
+                '/someütf/path',
+                new SiteAccess('foo', 'default'),
+                array(
+                    'name' => 'foo',
+                    'type' => 1,
+                    'uri_part' => array(),
+                ),
+            ),
+            array(
                 '/env/matching',
                 '/env/matching',
                 new SiteAccess('foo', 'env'),


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25739

Legacy siteaccess matching (and ezur()) is broken when using utf-8 characters after setting up urlalias_uri.
Basically, such uri's will then be considered as part of the siteaccess, then washed, which generates 404 urls

The problem is that utf8 pathinfo is compared to urlencoded semanticPathInfo, see also https://github.com/ezsystems/ezpublish-kernel/pull/1522