### PR TITLE
Fix EZP-25960: Double layout using legacy /layout/set module and LegacyKernelController

### DIFF
--- a/bundle/Resources/config/routing.yml
+++ b/bundle/Resources/config/routing.yml
@@ -26,3 +26,10 @@ _ezpublishLegacyRest:
         _controller: ezpublish_legacy.rest.controller:restAction
     requirements:
         path: .*
+
+_ezpublishLegacyLayoutSet:
+    path: /layout/set/{path}
+    defaults:
+        _controller: ezpublish_legacy.controller:indexAction
+    requirements:
+        path: .+

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -123,7 +123,7 @@ services:
 
     ezpublish_legacy.response_manager:
         class: %ezpublish_legacy.response_manager.class%
-        arguments: ["@templating", "@ezpublish.config.resolver"]
+        arguments: ["@templating", "@ezpublish.config.resolver", "@request_stack"]
 
     ezpublish_legacy.controller:
         class: %ezpublish_legacy.controller.class%


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-25960

When using `/layout/set` legacy module through `LegacyKernelController` having a module layout configured, result from legacy kernel is rendered using this module layout.
However, when using `/layout/set`, you already define a layout in legacy stack (via `layout.ini`. Problem is that the result from `/layout/set` will be embedded in the configured module layout, which can give very
unexpected results.
Best example is that when you want to render XML, JSON or anything not HTML, you'll have the result embedded in some HTML layout.)

This patch adds `_ezpublishLegacyLayoutSet` route which corresponds to `/layout/set` module, and ensures that if this route is used through legacy kernel, custom layout won't be used.
This fixes the usual behavior of layout module.