### PR TITLE
Fix EZP-25089: Clear persistence cache on object state assignment

### DIFF
--- a/bundle/Cache/PersistenceCachePurger.php
+++ b/bundle/Cache/PersistenceCachePurger.php
@@ -248,6 +248,20 @@ class PersistenceCachePurger implements CacheClearerInterface
     }
 
     /**
+     * Clear object state assignment persistence cache by content id.
+     *
+     * @param int $contentId
+     */
+    public function stateAssign($contentId)
+    {
+        if ($this->allCleared === true || $this->enabled === false) {
+            return;
+        }
+
+        $this->cache->clear('objectstate', 'byContent', $contentId);
+    }
+
+    /**
      * Clear all user persistence cache.
      *
      * @param int|null $id Purges all users cache if null

--- a/bundle/LegacyMapper/Configuration.php
+++ b/bundle/LegacyMapper/Configuration.php
@@ -215,6 +215,7 @@ class Configuration implements EventSubscriberInterface
         $ezpEvent->attach('content/section/cache', array($this->persistenceCachePurger, 'section'));
         $ezpEvent->attach('user/cache/all', array($this->persistenceCachePurger, 'user'));
         $ezpEvent->attach('content/translations/cache', array($this->persistenceCachePurger, 'languages'));
+        $ezpEvent->attach('content/state/assign', array($this->persistenceCachePurger, 'stateAssign'));
 
         // Register image alias removal listeners
         $ezpEvent->attach('image/removeAliases', array($this->aliasCleaner, 'removeAliases'));


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-25089

Before this patch, you would end up in a scenario where an object state was changed from being not available to available but the front-end would crash with an error related to the old state.

Needs to be combined with https://github.com/ezsystems/ezpublish-legacy/pull/1257