### PR TITLE
QA: Fix EZP-26181: Content with same name as URL matcher will lead to broken links

### DIFF
--- a/bundle/LegacyMapper/SiteAccess.php
+++ b/bundle/LegacyMapper/SiteAccess.php
@@ -81,25 +81,16 @@ class SiteAccess implements EventSubscriberInterface
 
         // uri_part
         $pathinfo = str_replace($request->attributes->get('viewParametersString'), '', rawurldecode($request->getPathInfo()));
-        $semanticPathinfo = $request->attributes->get('semanticPathinfo', $pathinfo);
-        if ($pathinfo != $semanticPathinfo) {
-            $aPathinfo = explode('/', substr($pathinfo, 1));
-            $aSemanticPathinfo = explode('/', substr($semanticPathinfo, 1));
-            $aFragmentPathInfo = $this->getFragmentPathItems();
-            if ($aFragmentPathInfo !== ['_fragment']) {
-                while (count($aFragmentPathInfo) > 0 &&
-                       end($aPathinfo) === end($aFragmentPathInfo)) {
-                    array_pop($aPathinfo);
-                    array_pop($aFragmentPathInfo);
-                }
-            } else {
-                while (count($aSemanticPathinfo) > 0 &&
-                       end($aPathinfo) === end($aSemanticPathinfo)) {
-                    array_pop($aPathinfo);
-                    array_pop($aSemanticPathinfo);
-                }
-            }
-            $uriPart = $aPathinfo;
+        $fragmentPathInfo = implode('/', $this->getFragmentPathItems());
+        if ($fragmentPathInfo !== '_fragment') {
+            $semanticPathinfo = $fragmentPathInfo;
+        } else {
+            $semanticPathinfo = $request->attributes->get('semanticPathinfo', $pathinfo);
+        }
+        $pos = mb_strrpos($pathinfo, $semanticPathinfo);
+        if ($pathinfo != $semanticPathinfo && $pos !== false) {
+            $uriPart = mb_substr($pathinfo, 1, $pos - 1);
+            $uriPart = explode('/', $uriPart);
         }
 
         // Handle host_uri match

--- a/bundle/LegacyMapper/SiteAccess.php
+++ b/bundle/LegacyMapper/SiteAccess.php
@@ -85,7 +85,21 @@ class SiteAccess implements EventSubscriberInterface
         if ($pathinfo != $semanticPathinfo) {
             $aPathinfo = explode('/', substr($pathinfo, 1));
             $aSemanticPathinfo = explode('/', substr($semanticPathinfo, 1));
-            $uriPart = array_diff($aPathinfo, $aSemanticPathinfo, $this->getFragmentPathItems());
+            $aFragmentPathInfo = $this->getFragmentPathItems();
+            if ($aFragmentPathInfo !== ['_fragment']) {
+                while (count($aFragmentPathInfo) > 0 &&
+                       end($aPathinfo) === end($aFragmentPathInfo)) {
+                    array_pop($aPathinfo);
+                    array_pop($aFragmentPathInfo);
+                }
+            } else {
+                while (count($aSemanticPathinfo) > 0 &&
+                       end($aPathinfo) === end($aSemanticPathinfo)) {
+                    array_pop($aPathinfo);
+                    array_pop($aSemanticPathinfo);
+                }
+            }
+            $uriPart = $aPathinfo;
         }
 
         // Handle host_uri match

--- a/bundle/Tests/LegacyMapper/SiteAccessTest.php
+++ b/bundle/Tests/LegacyMapper/SiteAccessTest.php
@@ -20,13 +20,25 @@ class SiteAccessTest extends PHPUnit_Framework_TestCase
      */
     private $request;
 
+    private $systemErrorLevel;
+
     protected function setUp()
     {
         parent::setUp();
+
+        // Silence E_DEPRECATED to avoid issues with notices from legacy in regards to constructors
+        $this->systemErrorLevel = error_reporting(E_ALL & ~E_DEPRECATED);
+
         $this->request = $this
             ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
             ->setMethods(['getPathInfo'])
             ->getMock();
+    }
+
+    protected function tearDown()
+    {
+        error_reporting($this->systemErrorLevel);
+        parent::tearDown();
     }
 
     public function buildKernelProvider()
@@ -49,6 +61,30 @@ class SiteAccessTest extends PHPUnit_Framework_TestCase
                 '/Media/Images/EZP-26181',
                 '/Ädmin/Media/Images/EZP-26181',
                 ['Ädmin'],
+            ],
+            [
+                '',
+                '/Admin/Media',
+                '/Admin/Media/Admin/Media',
+                ['Admin', 'Media'],
+            ],
+            [
+                '',
+                '/Admin/Media/Admin/Media',
+                '/Admin/Media/Admin/Media/Admin/Media',
+                ['Admin', 'Media'],
+            ],
+            [
+                '',
+                '/A/B',
+                '/A/B/A/B',
+                ['A', 'B'],
+            ],
+            [
+                '',
+                '/A/B/A/B',
+                '/A/B/A/B',
+                [],
             ],
         ];
     }

--- a/bundle/Tests/LegacyMapper/SiteAccessTest.php
+++ b/bundle/Tests/LegacyMapper/SiteAccessTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * File containing the SiteAccessTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishLegacyBundle\Tests\LegacyMapper;
+
+use eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\SiteAccess as SiteAccessMapper;
+use eZ\Publish\Core\MVC\Legacy\Event\PreBuildKernelWebHandlerEvent;
+use eZSiteAccess;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+class SiteAccessTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\HttpFoundation\Request
+     */
+    private $request;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->request = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->setMethods(['getPathInfo'])
+            ->getMock();
+    }
+
+    public function buildKernelProvider()
+    {
+        return [
+            [
+                '/(Foo)/Bar',
+                '/Media/Images/Admin/EZP-26181',
+                '/Admin/Media/Images/Admin/EZP-26181/(Foo)/Bar',
+                ['Admin'],
+            ],
+            [
+                '',
+                '/Media/Images/Ädmin/EZP-26181',
+                '/Ädmin/Media/Images/Ädmin/EZP-26181',
+                ['Ädmin'],
+            ],
+            [
+                '',
+                '/Media/Images/EZP-26181',
+                '/Ädmin/Media/Images/EZP-26181',
+                ['Ädmin'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider buildKernelProvider
+     */
+    public function testOnBuildKernelWebHandler($viewParams, $semanticPathInfo, $pathInfo, $uriPart)
+    {
+        $this->request->attributes->set('viewParametersString', $viewParams);
+        $this->request->attributes->set('semanticPathinfo', $semanticPathInfo);
+
+        $this->request
+            ->expects($this->once())
+            ->method('getPathInfo')
+            ->will($this->returnValue($pathInfo));
+
+        $siteAccess = $this
+            ->getMockBuilder('eZ\Publish\Core\MVC\Symfony\SiteAccess')
+            ->setConstructorArgs(['Admin', eZSiteAccess::TYPE_URI, null])
+            ->getMock();
+
+        $containerMock = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $containerMock
+            ->expects($this->once())
+            ->method('get')
+            ->with('ezpublish.siteaccess')
+            ->will($this->returnValue($siteAccess));
+
+        $siteAccessMapper = new SiteAccessMapper([]);
+        $siteAccessMapper->setContainer($containerMock);
+        $event = new PreBuildKernelWebHandlerEvent(new ParameterBag(), $this->request);
+
+        $siteAccessMapper->onBuildKernelWebHandler($event);
+        $this->assertSame(
+            $uriPart,
+            $event->getParameters()->get('siteaccess[uri_part]', null, true)
+        );
+    }
+}


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-26181
> Status: QA

This is caused by the use of `array_diff` to determine the siteaccess part of the URL, here:
https://github.com/ezsystems/LegacyBridge/blob/master/bundle/LegacyMapper/SiteAccess.php#L88
When the the path-without-siteaccess contains an element that equals the siteaccess, the diff is empty, and the siteaccess is not found, and subsequently removed from all URLs.

Example: The siteaccess is `Admin` and we're requesting `/Media/Images/Admin/EZP-26181`. Before this PR, this means that:
`$pathinfo = /Admin/Media/Images/Admin/EZP-26181`
`$semanticPathinfo = /Media/Images/Admin/EZP-26181`
The paths are broken into path element arrays, and diffed:
```
array_diff(
    [Admin, Media, Images, Admin, EZP-26181],
    [Media, Images, Admin, EZP-26181]
)
```
The result of this is an empty array, as all elements of the second parameter exist in the first - array_diff() doesn't care that "Admin" is in there twice. So the `$uriPart` is empty, meaning the siteaccess was not found.

The fix is to start at the end/right of the paths, and chop off the bit that is equal. What's left, literally and figuratively, is the siteaccess uri part.

Example: After the PR, we have the same input strings:
`$pathinfo = /Admin/Media/Images/Admin/EZP-26181`
`$semanticPathinfo = /Media/Images/Admin/EZP-26181`
Now we lookup the position of `$semanticPathinfo` within `$pathinfo` directly using mb_strrpos (i.e. backwards). The `$uriPart` is taken to be whatever is to the left of that, i.e. `/Admin`.

NB: This fixes the bug according to steps-to-reproduce, but I'm not sure I'm dealing with fragment path items the right way.

- [x] Add test
- [x] Deal with the posibility of mb_strrpos() returning false? i.e. semantic pathinfo not found within pathinfo, which Should Not Happen(TM)