### PR TITLE
Fix fatal errors with Twig 1.25.0 and Twig 2.0

### DIFF
--- a/mvc/Templating/Twig/Template.php
+++ b/mvc/Templating/Twig/Template.php
@@ -66,6 +66,14 @@ class Template extends Twig_Template
     /**
      * {@inheritdoc}
      */
+    public function getDebugInfo()
+    {
+        return array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function doDisplay(array $context, array $blocks = array())
     {
     }

--- a/mvc/Templating/Twig/Template.php
+++ b/mvc/Templating/Twig/Template.php
@@ -74,6 +74,14 @@ class Template extends Twig_Template
     /**
      * {@inheritdoc}
      */
+    public function getSource()
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function doDisplay(array $context, array $blocks = array())
     {
     }


### PR DESCRIPTION
As of Twig 1.25.0, there's a fatal error:

> Fatal error: Class eZ\Publish\Core\MVC\Legacy\Templating\Twig\Template contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Twig_Template::getDebugInfo)

Caused by https://github.com/twigphp/Twig/pull/2132

@andrerom Can you make a patch release ASAP, please?

EDIT: Also added a second method to make sure there's no fatal error in Twig 2.0