### PR TITLE
Use FQCN in Twig_Extension::getName

### DIFF
--- a/mvc/Templating/Twig/Extension/LegacyExtension.php
+++ b/mvc/Templating/Twig/Extension/LegacyExtension.php
@@ -84,7 +84,7 @@ class LegacyExtension extends Twig_Extension implements Twig_Extension_InitRunti
      */
     public function getName()
     {
-        return 'ezpublish.legacy';
+        return get_class($this);
     }
 
     /**

--- a/mvc/Templating/Twig/Node/LegacyIncludeNode.php
+++ b/mvc/Templating/Twig/Node/LegacyIncludeNode.php
@@ -34,9 +34,11 @@ class LegacyIncludeNode extends Twig_Node
 
     public function compile(Twig_Compiler $compiler)
     {
+        $legacyExtensionClass = 'eZ\Publish\Core\MVC\Legacy\Templating\Twig\Extension\LegacyExtension';
+
         $compiler
             ->addDebugInfo($this)
-            ->write("echo \$this->env->getExtension( 'ezpublish.legacy' )->renderTemplate( ")
+            ->write("echo \$this->env->getExtension( '" . $legacyExtensionClass . "' )->renderTemplate( ")
             ->subcompile($this->getNode('tplPath'))
             ->raw(', ')
             ->subcompile($this->getNode('params'))


### PR DESCRIPTION
`Twig_Extension::getName` is deprecated in Twig 1.26 (https://github.com/twigphp/Twig/pull/2148) and removed in Twig 2.0.

Using FQCN in `getName` makes sure the extension keeps functioning in Twig 1.x as well as 2.0, where FQCN is used to reference the extensions.