### PR TITLE
Fix EZP-26393: Missing options for ezpublish_legacy.kernel_handler.cli

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -26,7 +26,8 @@ parameters:
     ezpublish_legacy.website_toolbar.controller.class: eZ\Bundle\EzPublishLegacyBundle\Controller\WebsiteToolbarController
 
     ezpublish_legacy.kernel_handler.cli.class: eZ\Publish\Core\MVC\Legacy\Kernel\CLIHandler
-    ezpublish_legacy.kernel_handler.cli.options: {}
+    ezpublish_legacy.kernel_handler.cli.options:
+        use-modules: true
 
     # See ezpublish_legacy.webconfigurator
     ezpublish_legacy.webconfigurator.factory.class: eZ\Bundle\EzPublishLegacyBundle\SetupWizard\ConfiguratorFactory


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-26393

This patch enforces `use-modules` to `true`, so that operations like `content/publish` can be used from legacy scripts:

```php
eZOperationHandler::execute('content', 'publish', [
    'object_id' => $objectId, 
    'version' => $version,
]);
```