### PR TITLE
Modify permissions folder check.

### DIFF
--- a/bundle/Controller/LegacySetupController.php
+++ b/bundle/Controller/LegacySetupController.php
@@ -99,7 +99,7 @@ class LegacySetupController extends ContainerAware
                                 'setup.ini' => array(
                                     // checked folders are relative to the ezpublish_legacy folder
                                     'directory_permissions' => array(
-                                        'CheckList' => '../ezpublish/logs;../ezpublish/cache;../ezpublish/config;' .
+                                        'CheckList' => '../app/logs;../app/cache;../app/config;' .
                                         eZINI::instance('setup.ini')->variable('directory_permissions', 'CheckList'),
                                     ),
                                 ),


### PR DESCRIPTION
CheckList was using legacy ezpublish folder name in relative path. Updated CheckList with new app folder name. A warning was being thrown during the ezsetup wizard when trying to install the legacybundle overtop of ezplatform.