### PR TITLE
Add support for clean legacy install

### DIFF
--- a/bundle/Installer/CleanInstaller.php
+++ b/bundle/Installer/CleanInstaller.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace eZ\Bundle\EzPublishLegacyBundle\Installer;
+
+class CleanInstaller extends DbBasedInstaller implements Installer
+{
+    public function createConfiguration()
+    {
+    }
+
+    public function importSchema()
+    {
+        $this->runQueriesFromFile('ezpublish_legacy/kernel/sql/mysql/kernel_schema.sql');
+        $this->runQueriesFromFile('ezpublish_legacy/kernel/sql/mysql/cluster_dfs_schema.sql');
+    }
+
+    public function importData()
+    {
+        $this->runQueriesFromFile(
+            'ezpublish_legacy/kernel/sql/common/cleandata.sql'
+        );
+    }
+
+    public function importBinaries()
+    {
+    }
+}

--- a/bundle/Installer/DbBasedInstaller.php
+++ b/bundle/Installer/DbBasedInstaller.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace eZ\Bundle\EzPublishLegacyBundle\Installer;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Filesystem\Filesystem;
+
+class DbBasedInstaller
+{
+    /** @var Connection */
+    protected $db;
+
+    /** @var \Symfony\Component\Console\Output\OutputInterface */
+    protected $output;
+
+    public function __construct(Connection $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     */
+    public function setOutput($output)
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * Copy and override configuration file.
+     *
+     * @param string $source
+     * @param string $target
+     */
+    protected function copyConfigurationFile($source, $target)
+    {
+        $fs = new Filesystem();
+        $fs->copy($source, $target, true);
+
+        if (!$this->output->isQuiet()) {
+            $this->output->writeln("Copied $source to $target");
+        }
+    }
+
+    protected function runQueriesFromFile($file)
+    {
+        $queries = array_filter(preg_split('(;\\s*$)m', file_get_contents($file)));
+
+        if (!$this->output->isQuiet()) {
+            $this->output->writeln(
+                sprintf(
+                    'Executing %d queries from %s on database %s',
+                    count($queries),
+                    $file,
+                    $this->db->getDatabase()
+                )
+            );
+        }
+
+        foreach ($queries as $query) {
+            $this->db->exec($query);
+        }
+    }
+}

--- a/bundle/Installer/Installer.php
+++ b/bundle/Installer/Installer.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace eZ\Bundle\EzPublishLegacyBundle\Installer;
+
+/**
+ * Interface Installer.
+ *
+ * Simple SQL based installer interface for eZ Platform 1.0, will be replaced by a new interface in the future that
+ * uses API/SPI (via future import/export functionality) to support cluster and several different storage engines.
+ * Such change will also move responsibility of repository init (base schema and minimal data) to storage engine
+ * so this is not in installers. Further info: https://jira.ez.no/browse/EZP-25368
+ */
+interface Installer
+{
+    /**
+     * Handle inserting of schema, schema should ideally be in ISO SQL format.
+     */
+    public function importSchema();
+
+    /**
+     * Handle inserting of sql dump, sql dump should ideally be in ISO SQL format.
+     */
+    public function importData();
+
+    /**
+     * @deprecated Inactive since 6.1, further info: https://jira.ez.no/browse/EZP-25369
+     */
+    public function createConfiguration();
+
+    /**
+     * Handle optional import of binary files to var folder.
+     */
+    public function importBinaries();
+}

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -77,6 +77,8 @@ parameters:
 
     ezpublish_legacy.setup_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\SetupListener
 
+    ezpublish_legacy.installer.clean_installer.class:  eZ\Bundle\EzPublishLegacyBundle\Installer\CleanInstaller
+
 services:
     ezpublish_legacy.kernel:
         alias: ezpublish_legacy.kernel.lazy
@@ -333,3 +335,10 @@ services:
             - "%ezpublish.siteaccess.default%"
         tags:
             - { name: kernel.event_subscriber }
+
+    ezpublish_legacy.installer.clean_installer:
+        class: "%ezpublish_legacy.installer.clean_installer.class%"
+        parent: ezplatform.installer.db_based_installer
+        tags:
+            - {name: ezplatform.installer, type: legacy_clean}
+


### PR DESCRIPTION
This adds support for a CLI installation of legacy clean content using : 

`php app/console ezplatform:install legacy_clean`
