### PR TITLE
EZP-27249: Fix routerpass to use defined class

### DIFF
--- a/bundle/DependencyInjection/Compiler/RoutingPass.php
+++ b/bundle/DependencyInjection/Compiler/RoutingPass.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler;
 
+use eZ\Bundle\EzPublishLegacyBundle\Routing\DefaultRouter as DefaultRouter;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -21,6 +22,10 @@ class RoutingPass implements CompilerPassInterface
         if (!$container->hasDefinition('router.default')) {
             return;
         }
+
+        $container
+            ->findDefinition('router.default')
+            ->setClass(DefaultRouter::class);
 
         $defaultRouterDef = $container->getDefinition('router.default');
         $defaultRouterDef->addMethodCall(

--- a/bundle/DependencyInjection/Compiler/RoutingPass.php
+++ b/bundle/DependencyInjection/Compiler/RoutingPass.php
@@ -22,14 +22,11 @@ class RoutingPass implements CompilerPassInterface
             return;
         }
 
-        $container
-            ->findDefinition('router.default')
-            ->setClass('eZ\Bundle\EzPublishLegacyBundle\Routing\DefaultRouter');
-
-        $defaultRouterDef = $container->getDefinition('router.default');
-        $defaultRouterDef->addMethodCall(
-            'setLegacyAwareRoutes',
-            ['%ezpublish.default_router.legacy_aware_routes%']
-        );
+        $container->getDefinition('router.default')
+            ->setClass('eZ\Bundle\EzPublishLegacyBundle\Routing\DefaultRouter')
+            ->addMethodCall(
+                'setLegacyAwareRoutes',
+                ['%ezpublish.default_router.legacy_aware_routes%']
+            );
     }
 }

--- a/bundle/DependencyInjection/Compiler/RoutingPass.php
+++ b/bundle/DependencyInjection/Compiler/RoutingPass.php
@@ -8,7 +8,6 @@
  */
 namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler;
 
-use eZ\Bundle\EzPublishLegacyBundle\Routing\DefaultRouter as DefaultRouter;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -25,7 +24,7 @@ class RoutingPass implements CompilerPassInterface
 
         $container
             ->findDefinition('router.default')
-            ->setClass(DefaultRouter::class);
+            ->setClass('eZ\Bundle\EzPublishLegacyBundle\Routing\DefaultRouter');
 
         $defaultRouterDef = $container->getDefinition('router.default');
         $defaultRouterDef->addMethodCall(

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -6,7 +6,6 @@ parameters:
     ezpublish.default_router.legacy_aware_routes: ['_ezpublishLegacyTreeMenu', 'ezpublish_rest_', '_ezpublishPreviewContent', '_wdt', '_profiler', '_assetic']
 
     # Core overrides
-    router.class: eZ\Bundle\EzPublishLegacyBundle\Routing\DefaultRouter
     ezpublish.security.login_listener.class: eZ\Bundle\EzPublishLegacyBundle\Security\SecurityListener
     security.authentication.listener.rememberme.class: eZ\Bundle\EzPublishLegacyBundle\Security\RememberMeListener
 


### PR DESCRIPTION
Follow kernel and no longer use router.class parameter