### PR TITLE
Symfony 3.x compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /vendor/
 composer.lock
 ezpublish_legacy
+var
 bin
 config.php
 .php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -19,6 +19,7 @@ return PhpCsFixer\Config::create()
             ->in(__DIR__)
             ->exclude([
                 'vendor',
+                'ezpublish_legacy',
             ])
             ->files()->name('*.php')
     )

--- a/bundle/Controller/LegacyRestController.php
+++ b/bundle/Controller/LegacyRestController.php
@@ -36,7 +36,7 @@ class LegacyRestController extends Controller
 
         $result = ezpKernelRest::getResponse();
         if ($result === null) {
-            throw new Exception('Rest Kernel run failed');
+            throw new \Exception('Rest Kernel run failed');
         }
 
         return new Response(

--- a/bundle/Controller/LegacySetupController.php
+++ b/bundle/Controller/LegacySetupController.php
@@ -10,7 +10,8 @@
 namespace eZ\Bundle\EzPublishLegacyBundle\Controller;
 
 use eZ\Publish\Core\MVC\Legacy\Kernel\Loader;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Response;
 use eZ\Publish\Core\MVC\Symfony\ConfigDumperInterface;
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Configuration\LegacyConfigResolver;
@@ -18,8 +19,10 @@ use eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger;
 use eZINI;
 use eZCache;
 
-class LegacySetupController extends ContainerAware
+class LegacySetupController implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * The legacy kernel instance (eZ Publish 4).
      *

--- a/bundle/Controller/LegacySetupController.php
+++ b/bundle/Controller/LegacySetupController.php
@@ -87,7 +87,7 @@ class LegacySetupController extends ContainerAware
         $this->kernelFactory->setBuildEventsEnabled(false);
 
         /** @var $request \Symfony\Component\HttpFoundation\ParameterBag */
-        $request = $this->container->get('request')->request;
+        $request = $this->container->get('request_stack')->getCurrentRequest()->request;
 
         // inject the extra ezpublish-community folders we want permissions checked for
         switch ($request->get('eZSetup_current_step')) {

--- a/bundle/Controller/WebsiteToolbarController.php
+++ b/bundle/Controller/WebsiteToolbarController.php
@@ -14,7 +14,7 @@ use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\Helper\ContentPreviewHelper;
 use eZ\Publish\Core\MVC\Symfony\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Templating\EngineInterface;
@@ -22,8 +22,8 @@ use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as Authorizatio
 
 class WebsiteToolbarController extends Controller
 {
-    /** @var \Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface */
-    private $csrfProvider;
+    /** @var \Symfony\Component\Security\Csrf\CsrfTokenManagerInterface */
+    private $csrfTokenManager;
 
     /** @var \Symfony\Component\Templating\EngineInterface */
     private $legacyTemplateEngine;
@@ -46,13 +46,13 @@ class WebsiteToolbarController extends Controller
         LocationService $locationService,
         AuthorizationCheckerInterface $authChecker,
         ContentPreviewHelper $previewHelper,
-        CsrfProviderInterface $csrfProvider = null
+        CsrfTokenManagerInterface $csrfTokenManager = null
     ) {
         $this->legacyTemplateEngine = $engine;
         $this->contentService = $contentService;
         $this->locationService = $locationService;
         $this->authChecker = $authChecker;
-        $this->csrfProvider = $csrfProvider;
+        $this->csrfTokenManager = $csrfTokenManager;
         $this->previewHelper = $previewHelper;
     }
 
@@ -70,8 +70,8 @@ class WebsiteToolbarController extends Controller
     {
         $response = new Response();
 
-        if (isset($this->csrfProvider)) {
-            $parameters['form_token'] = $this->csrfProvider->generateCsrfToken('legacy');
+        if (isset($this->csrfTokenManager)) {
+            $parameters['form_token'] = $this->csrfTokenManager->getToken('legacy');
         }
 
         if ($this->previewHelper->isPreviewActive()) {

--- a/bundle/Controller/WebsiteToolbarController.php
+++ b/bundle/Controller/WebsiteToolbarController.php
@@ -71,7 +71,7 @@ class WebsiteToolbarController extends Controller
         $response = new Response();
 
         if (isset($this->csrfTokenManager)) {
-            $parameters['form_token'] = $this->csrfTokenManager->getToken('legacy');
+            $parameters['form_token'] = $this->csrfTokenManager->getToken('legacy')->getValue();
         }
 
         if ($this->previewHelper->isPreviewActive()) {

--- a/bundle/DependencyInjection/Compiler/RememberMeListenerPass.php
+++ b/bundle/DependencyInjection/Compiler/RememberMeListenerPass.php
@@ -21,7 +21,8 @@ class RememberMeListenerPass implements CompilerPassInterface
             return;
         }
 
-        $listenerDef = $container->findDefinition('security.authentication.listener.rememberme');
-        $listenerDef->addMethodCall('setConfigResolver', array(new Reference('ezpublish.config.resolver')));
+        $container->findDefinition('security.authentication.listener.rememberme')
+            ->setClass('eZ\Bundle\EzPublishLegacyBundle\Security\RememberMeListener')
+            ->addMethodCall('setConfigResolver', array(new Reference('ezpublish.config.resolver')));
     }
 }

--- a/bundle/DependencyInjection/Compiler/RoutingPass.php
+++ b/bundle/DependencyInjection/Compiler/RoutingPass.php
@@ -29,5 +29,10 @@ class RoutingPass implements CompilerPassInterface
                 'setLegacyAwareRoutes',
                 ['%ezpublish.default_router.legacy_aware_routes%']
             );
+
+        if ($container->hasDefinition('ezpublish_rest.templated_router')) {
+            $container->getDefinition('ezpublish_rest.templated_router')
+                ->setClass('eZ\Bundle\EzPublishLegacyBundle\Routing\DefaultRouter');
+        }
     }
 }

--- a/bundle/DependencyInjection/Compiler/TwigPass.php
+++ b/bundle/DependencyInjection/Compiler/TwigPass.php
@@ -26,7 +26,8 @@ class TwigPass implements CompilerPassInterface
 
         // Adding setLegacyEngine method call here to avoid side effect in redefining the twig service completely.
         // Mentioned side effects are losing extensions/loaders addition for which method calls are added in the TwigEnvironmentPass
-        $def = $container->getDefinition('twig');
-        $def->addMethodCall('setEzLegacyEngine', array(new Reference('templating.engine.eztpl')));
+        $container->getDefinition('twig')
+            ->setClass('eZ\Publish\Core\MVC\Legacy\Templating\Twig\Environment')
+            ->addMethodCall('setEzLegacyEngine', array(new Reference('templating.engine.eztpl')));
     }
 }

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -94,6 +94,7 @@ services:
             - "@?logger"
         calls:
             - [setContainer, ["@service_container"]]
+            - [setRequestStack, ["@request_stack"]]
 
     ezpublish_legacy.rest.kernel_handler:
         class: "%ezpublish_legacy.kernel_handler.rest.class%"

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -173,7 +173,7 @@ services:
             - "@ezpublish.api.service.location"
             - "@security.authorization_checker"
             - "@ezpublish.content_preview_helper"
-            - "@?form.csrf_provider"
+            - "@?security.csrf.token_manager"
 
     ezpublish_legacy.router:
         class: "%ezpublish_legacy.router.class%"

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -7,7 +7,6 @@ parameters:
 
     # Core overrides
     ezpublish.security.login_listener.class: eZ\Bundle\EzPublishLegacyBundle\Security\SecurityListener
-    security.authentication.listener.rememberme.class: eZ\Bundle\EzPublishLegacyBundle\Security\RememberMeListener
 
     ezpublish_legacy.kernel.lazy_loader.class: eZ\Publish\Core\MVC\Legacy\Kernel\Loader
     ezpublish_legacy.kernel_handler.class: ezpKernelHandler

--- a/bundle/Resources/config/templating.yml
+++ b/bundle/Resources/config/templating.yml
@@ -12,7 +12,6 @@ parameters:
     # eZ Template as a real template engine
     templating.engine.eztpl.class: eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine
     assetic.eztpl_formula_loader.class: eZ\Publish\Core\MVC\Legacy\Templating\LegacyFormulaLoader
-    twig.class: eZ\Publish\Core\MVC\Legacy\Templating\Twig\Environment
     twig.loader.string.class: eZ\Publish\Core\MVC\Legacy\Templating\Twig\LoaderString
 
 services:

--- a/bundle/Routing/FallbackRouter.php
+++ b/bundle/Routing/FallbackRouter.php
@@ -94,7 +94,7 @@ class FallbackRouter implements RouterInterface, RequestMatcherInterface
      *
      * @param string $name The name of the route
      * @param mixed $parameters An array of parameters
-     * @param bool $absolute Whether to generate an absolute URL
+     * @param int $referenceType The type of reference to be generated (one of the constants)
      *
      * @throws \Symfony\Component\Routing\Exception\RouteNotFoundException
      * @throws \InvalidArgumentException
@@ -103,7 +103,7 @@ class FallbackRouter implements RouterInterface, RequestMatcherInterface
      *
      * @api
      */
-    public function generate($name, $parameters = array(), $absolute = false)
+    public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)
     {
         if ($name === self::ROUTE_NAME) {
             if (!isset($parameters['module_uri'])) {
@@ -113,7 +113,7 @@ class FallbackRouter implements RouterInterface, RequestMatcherInterface
             $moduleUri = $parameters['module_uri'];
             unset($parameters['module_uri']);
 
-            return $this->urlGenerator->generate($moduleUri, $parameters, $absolute);
+            return $this->urlGenerator->generate($moduleUri, $parameters, $referenceType);
         }
 
         throw new RouteNotFoundException();

--- a/mvc/Kernel/Loader.php
+++ b/mvc/Kernel/Loader.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Legacy kernel loader.
@@ -68,6 +69,11 @@ class Loader
     /** @var ezpKernelHandler */
     private $restHandler;
 
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestStack
+     */
+    private $requestStack;
+
     public function __construct($legacyRootDir, $webrootDir, EventDispatcherInterface $eventDispatcher, URIHelper $uriHelper, LoggerInterface $logger = null)
     {
         $this->legacyRootDir = $legacyRootDir;
@@ -75,6 +81,14 @@ class Loader
         $this->eventDispatcher = $eventDispatcher;
         $this->uriHelper = $uriHelper;
         $this->logger = $logger;
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+     */
+    public function setRequestStack(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
     }
 
     /**
@@ -152,7 +166,7 @@ class Loader
 
                 $legacyParameters = new ParameterBag($defaultLegacyOptions);
                 $legacyParameters->set('service-container', $container);
-                $request = $container->get('request');
+                $request = $this->requestStack->getCurrentRequest();
 
                 if ($that->getBuildEventsEnabled()) {
                     // PRE_BUILD_LEGACY_KERNEL for non request related stuff
@@ -277,7 +291,7 @@ class Loader
                 chdir($legacyRootDir);
 
                 $legacyParameters = new ParameterBag();
-                $request = $container->get('request');
+                $request = $this->requestStack->getCurrentRequest();
 
                 if ($that->getBuildEventsEnabled()) {
                     // PRE_BUILD_LEGACY_KERNEL for non request related stuff

--- a/mvc/LegacyEvents.php
+++ b/mvc/LegacyEvents.php
@@ -25,7 +25,7 @@ final class LegacyEvents
     const PRE_BUILD_LEGACY_KERNEL_WEB = 'ezpublish_legacy.build_kernel_web_handler';
 
     /**
-     * The PRE_BUID_LEGACY_KERNEL occurs right before the build of the legacy handler (whatever the handler is used).
+     * The PRE_BUILD_LEGACY_KERNEL occurs right before the build of the legacy handler (whatever the handler is used).
      * This event allows to inject parameters in the legacy kernel (such as INI settings).
      *
      * The event listener method receives a


### PR DESCRIPTION
Removes usage of Symfony `*.class` parameters for compatibility with Symfony 3.x.

Also contains a followup to #88 by @wizhippo, due to https://github.com/ezsystems/ezpublish-kernel/pull/1910

Removes usage of `request` service.

Removes usage of `ContainerAware` abstract class.

Replaced deprecated CSRF token provider with token manager

Removed depreacted usage of `$absolute` argument in router

More fixes probably incoming :)