### PR TITLE
Add overriden NotFoundHttpException to have access to the original response

### DIFF
--- a/bundle/Exception/NotFoundHttpException.php
+++ b/bundle/Exception/NotFoundHttpException.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace eZ\Bundle\EzPublishLegacyBundle\Exception;
+
+use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException as BaseNotFoundHttpException;
+
+class NotFoundHttpException extends BaseNotFoundHttpException
+{
+    /**
+     * @var \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse
+     */
+    protected $originalResponse;
+
+    /**
+     * Constructor.
+     *
+     * @param string $message
+     * @param \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse $originalResponse
+     */
+    public function __construct($message, LegacyResponse $originalResponse = null)
+    {
+        parent::__construct($message);
+
+        $this->originalResponse = $originalResponse;
+    }
+
+    /**
+     * Returns the response.
+     *
+     * @return \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse
+     */
+    public function getOriginalResponse()
+    {
+        return $this->originalResponse;
+    }
+}

--- a/bundle/LegacyResponse/LegacyResponseManager.php
+++ b/bundle/LegacyResponse/LegacyResponseManager.php
@@ -14,7 +14,7 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use eZ\Bundle\EzPublishLegacyBundle\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Templating\EngineInterface;
 use DateTime;
@@ -104,13 +104,15 @@ class LegacyResponseManager
                     $errorMessage = isset($moduleResult['errorMessage']) ? $moduleResult['errorMessage'] : 'Access denied';
                     throw new AccessDeniedException($errorMessage);
                 }
-                // If having an "Not found" error code in non-legacy mode and conversation is true,
+
+                // If having an "Not found" error code in non-legacy mode and conversion is true,
                 // we send an NotFoundHttpException to be able to trigger error page in Symfony stack.
                 if ($moduleResult['errorCode'] == 404) {
                     if ($this->notFoundHttpConversion) {
                         $errorMessage = isset($moduleResult['errorMessage']) ? $moduleResult['errorMessage'] : 'Not found';
-                        throw new NotFoundHttpException($errorMessage);
+                        throw new NotFoundHttpException($errorMessage, $response);
                     }
+
                     @trigger_error(
                         "Legacy 404 error handling is deprecated, and will be removed in legacy-bridge 2.0.\n" .
                         'Use the not_found_http_conversion setting to use the new behavior and disable this notice.',


### PR DESCRIPTION
Now that #91 is done, it would greatly help to know what happened in legacy when a 404 error is received.

We have some siteaccesses that run in legacy mode set to false, but still display legacy 404 errors, so this would help facilitate that.

It is worthwhile to note that this behaviour (this custom 404 exception) would still be part of 2.0 release.