### PR TITLE
hasInstance method is missing in the Kernel.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /vendor/
 composer.lock
 ezpublish_legacy
+var
 bin
 config.php
 .php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,24 +1,21 @@
 <?php
-
-return Symfony\CS\Config\Config::create()
-    ->setUsingLinter(false)
-    ->setUsingCache(true)
-    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ->fixers([
-        'concat_with_spaces',
-        '-concat_without_spaces',
-        '-empty_return',
-        '-phpdoc_params',
-        '-phpdoc_separation',
-        '-phpdoc_to_comment',
-        '-spaces_cast',
-        '-blankline_after_open_tag',
-        '-single_blank_line_before_namespace',
-        // psr0 has weird issues with our PSR-4 layout, so deactivating it.
-        '-psr0',
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'array_syntax' => false,
+        'simplified_null_return' => false,
+        'phpdoc_align' => false,
+        'phpdoc_separation' => false,
+        'phpdoc_to_comment' => false,
+        'cast_spaces' => false,
+        'blank_line_after_opening_tag' => false,
+        'phpdoc_no_alias_tag' => false,
     ])
-    ->finder(
-        Symfony\CS\Finder\DefaultFinder::create()
+    ->setRiskyAllowed(true)
+    ->setFinder(
+        PhpCsFixer\Finder::create()
             ->in(__DIR__)
             ->exclude([
                 'vendor',
@@ -26,4 +23,3 @@ return Symfony\CS\Config\Config::create()
             ->files()->name('*.php')
     )
 ;
-

--- a/.php_cs
+++ b/.php_cs
@@ -19,6 +19,7 @@ return PhpCsFixer\Config::create()
             ->in(__DIR__)
             ->exclude([
                 'vendor',
+                'ezpublish_legacy',
             ])
             ->files()->name('*.php')
     )

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 cache:
   directories:

--- a/bundle/Cache/LegacyCachePurger.php
+++ b/bundle/Cache/LegacyCachePurger.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Cache;
 
 use eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\Configuration;
@@ -57,7 +58,7 @@ class LegacyCachePurger implements CacheClearerInterface
     /**
      * Clears any caches necessary.
      *
-     * @param string $cacheDir The cache directory.
+     * @param string $cacheDir the cache directory
      */
     public function clear($cacheDir)
     {

--- a/bundle/Cache/PersistenceCachePurger.php
+++ b/bundle/Cache/PersistenceCachePurger.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Cache;
 
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
@@ -285,7 +286,7 @@ class PersistenceCachePurger implements CacheClearerInterface
     /**
      * Clears any caches necessary.
      *
-     * @param string $cacheDir The cache directory.
+     * @param string $cacheDir the cache directory
      */
     public function clear($cacheDir)
     {

--- a/bundle/Cache/Switchable.php
+++ b/bundle/Cache/Switchable.php
@@ -5,6 +5,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Cache;
 
 trait Switchable

--- a/bundle/Cache/SwitchableHttpCachePurger.php
+++ b/bundle/Cache/SwitchableHttpCachePurger.php
@@ -5,6 +5,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Cache;
 
 use eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger;

--- a/bundle/Collector/LegacyTemplatesCollector.php
+++ b/bundle/Collector/LegacyTemplatesCollector.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Collector;
 
 use Symfony\Component\HttpFoundation\Request;

--- a/bundle/Collector/TemplateDebugInfo.php
+++ b/bundle/Collector/TemplateDebugInfo.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Collector;
 
 use eZ\Publish\Core\MVC\Legacy\Kernel as LegacyKernel;

--- a/bundle/Command/LegacyBundleInstallCommand.php
+++ b/bundle/Command/LegacyBundleInstallCommand.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Command;
 
 use RuntimeException;

--- a/bundle/Command/LegacyConfigurationCommand.php
+++ b/bundle/Command/LegacyConfigurationCommand.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;

--- a/bundle/Command/LegacyEmbedScriptCommand.php
+++ b/bundle/Command/LegacyEmbedScriptCommand.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;

--- a/bundle/Command/LegacyWrapperInstallCommand.php
+++ b/bundle/Command/LegacyWrapperInstallCommand.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;

--- a/bundle/Composer/ScriptHandler.php
+++ b/bundle/Composer/ScriptHandler.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Composer;
 
 use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler as DistributionBundleScriptHandler;

--- a/bundle/Controller.php
+++ b/bundle/Controller.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle;
 
 use eZ\Bundle\EzPublishCoreBundle\Controller as BaseController;

--- a/bundle/Controller/LegacyKernelController.php
+++ b/bundle/Controller/LegacyKernelController.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Controller;
 
 use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager;
@@ -46,7 +47,7 @@ class LegacyKernelController
      */
     private $legacyResponseManager;
 
-    /** @var  \eZ\Publish\Core\MVC\Legacy\Templating\LegacyHelper; */
+    /** @var \eZ\Publish\Core\MVC\Legacy\Templating\LegacyHelper; */
     private $legacyHelper;
 
     /**

--- a/bundle/Controller/LegacyRestController.php
+++ b/bundle/Controller/LegacyRestController.php
@@ -36,7 +36,7 @@ class LegacyRestController extends Controller
 
         $result = ezpKernelRest::getResponse();
         if ($result === null) {
-            throw new Exception('Rest Kernel run failed');
+            throw new \Exception('Rest Kernel run failed');
         }
 
         return new Response(

--- a/bundle/Controller/LegacyRestController.php
+++ b/bundle/Controller/LegacyRestController.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Controller;
 
 use eZ\Publish\Core\MVC\Symfony\Controller\Controller;

--- a/bundle/Controller/LegacySetupController.php
+++ b/bundle/Controller/LegacySetupController.php
@@ -10,7 +10,8 @@
 namespace eZ\Bundle\EzPublishLegacyBundle\Controller;
 
 use eZ\Publish\Core\MVC\Legacy\Kernel\Loader;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Response;
 use eZ\Publish\Core\MVC\Symfony\ConfigDumperInterface;
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Configuration\LegacyConfigResolver;
@@ -18,8 +19,10 @@ use eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger;
 use eZINI;
 use eZCache;
 
-class LegacySetupController extends ContainerAware
+class LegacySetupController implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * The legacy kernel instance (eZ Publish 4).
      *
@@ -87,7 +90,7 @@ class LegacySetupController extends ContainerAware
         $this->kernelFactory->setBuildEventsEnabled(false);
 
         /** @var $request \Symfony\Component\HttpFoundation\ParameterBag */
-        $request = $this->container->get('request')->request;
+        $request = $this->container->get('request_stack')->getCurrentRequest()->request;
 
         // inject the extra ezpublish-community folders we want permissions checked for
         switch ($request->get('eZSetup_current_step')) {

--- a/bundle/Controller/LegacySetupController.php
+++ b/bundle/Controller/LegacySetupController.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Controller;
 
 use eZ\Publish\Core\MVC\Legacy\Kernel\Loader;

--- a/bundle/Controller/LegacyTreeMenuController.php
+++ b/bundle/Controller/LegacyTreeMenuController.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Controller;
 
 use eZ\Publish\Core\MVC\Symfony\Controller\Controller;

--- a/bundle/Controller/PreviewController.php
+++ b/bundle/Controller/PreviewController.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Controller;
 
 use eZ\Publish\API\Repository\Values\Content\Content;

--- a/bundle/Controller/WebsiteToolbarController.php
+++ b/bundle/Controller/WebsiteToolbarController.php
@@ -14,7 +14,7 @@ use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\Helper\ContentPreviewHelper;
 use eZ\Publish\Core\MVC\Symfony\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Templating\EngineInterface;
@@ -22,8 +22,8 @@ use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as Authorizatio
 
 class WebsiteToolbarController extends Controller
 {
-    /** @var \Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface */
-    private $csrfProvider;
+    /** @var \Symfony\Component\Security\Csrf\CsrfTokenManagerInterface */
+    private $csrfTokenManager;
 
     /** @var \Symfony\Component\Templating\EngineInterface */
     private $legacyTemplateEngine;
@@ -46,13 +46,13 @@ class WebsiteToolbarController extends Controller
         LocationService $locationService,
         AuthorizationCheckerInterface $authChecker,
         ContentPreviewHelper $previewHelper,
-        CsrfProviderInterface $csrfProvider = null
+        CsrfTokenManagerInterface $csrfTokenManager = null
     ) {
         $this->legacyTemplateEngine = $engine;
         $this->contentService = $contentService;
         $this->locationService = $locationService;
         $this->authChecker = $authChecker;
-        $this->csrfProvider = $csrfProvider;
+        $this->csrfTokenManager = $csrfTokenManager;
         $this->previewHelper = $previewHelper;
     }
 
@@ -70,8 +70,8 @@ class WebsiteToolbarController extends Controller
     {
         $response = new Response();
 
-        if (isset($this->csrfProvider)) {
-            $parameters['form_token'] = $this->csrfProvider->generateCsrfToken('legacy');
+        if (isset($this->csrfTokenManager)) {
+            $parameters['form_token'] = $this->csrfTokenManager->getToken('legacy')->getValue();
         }
 
         if ($this->previewHelper->isPreviewActive()) {

--- a/bundle/Controller/WebsiteToolbarController.php
+++ b/bundle/Controller/WebsiteToolbarController.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Controller;
 
 use eZ\Publish\API\Repository\ContentService;

--- a/bundle/DependencyInjection/Compiler/LegacyBundlesPass.php
+++ b/bundle/DependencyInjection/Compiler/LegacyBundlesPass.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/bundle/DependencyInjection/Compiler/LegacyPass.php
+++ b/bundle/DependencyInjection/Compiler/LegacyPass.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/bundle/DependencyInjection/Compiler/LegacySessionPass.php
+++ b/bundle/DependencyInjection/Compiler/LegacySessionPass.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/bundle/DependencyInjection/Compiler/RelatedSiteAccessesCleanupPass.php
+++ b/bundle/DependencyInjection/Compiler/RelatedSiteAccessesCleanupPass.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/bundle/DependencyInjection/Compiler/RememberMeListenerPass.php
+++ b/bundle/DependencyInjection/Compiler/RememberMeListenerPass.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/bundle/DependencyInjection/Compiler/RememberMeListenerPass.php
+++ b/bundle/DependencyInjection/Compiler/RememberMeListenerPass.php
@@ -21,7 +21,8 @@ class RememberMeListenerPass implements CompilerPassInterface
             return;
         }
 
-        $listenerDef = $container->findDefinition('security.authentication.listener.rememberme');
-        $listenerDef->addMethodCall('setConfigResolver', array(new Reference('ezpublish.config.resolver')));
+        $container->findDefinition('security.authentication.listener.rememberme')
+            ->setClass('eZ\Bundle\EzPublishLegacyBundle\Security\RememberMeListener')
+            ->addMethodCall('setConfigResolver', array(new Reference('ezpublish.config.resolver')));
     }
 }

--- a/bundle/DependencyInjection/Compiler/RoutingPass.php
+++ b/bundle/DependencyInjection/Compiler/RoutingPass.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/bundle/DependencyInjection/Compiler/RoutingPass.php
+++ b/bundle/DependencyInjection/Compiler/RoutingPass.php
@@ -23,10 +23,11 @@ class RoutingPass implements CompilerPassInterface
             return;
         }
 
-        $defaultRouterDef = $container->getDefinition('router.default');
-        $defaultRouterDef->addMethodCall(
-            'setLegacyAwareRoutes',
-            ['%ezpublish.default_router.legacy_aware_routes%']
-        );
+        $container->getDefinition('router.default')
+            ->setClass('eZ\Bundle\EzPublishLegacyBundle\Routing\DefaultRouter')
+            ->addMethodCall(
+                'setLegacyAwareRoutes',
+                ['%ezpublish.default_router.legacy_aware_routes%']
+            );
     }
 }

--- a/bundle/DependencyInjection/Compiler/RoutingPass.php
+++ b/bundle/DependencyInjection/Compiler/RoutingPass.php
@@ -29,5 +29,10 @@ class RoutingPass implements CompilerPassInterface
                 'setLegacyAwareRoutes',
                 ['%ezpublish.default_router.legacy_aware_routes%']
             );
+
+        if ($container->hasDefinition('ezpublish_rest.templated_router')) {
+            $container->getDefinition('ezpublish_rest.templated_router')
+                ->setClass('eZ\Bundle\EzPublishLegacyBundle\Routing\DefaultRouter');
+        }
     }
 }

--- a/bundle/DependencyInjection/Compiler/TwigPass.php
+++ b/bundle/DependencyInjection/Compiler/TwigPass.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/bundle/DependencyInjection/Compiler/TwigPass.php
+++ b/bundle/DependencyInjection/Compiler/TwigPass.php
@@ -26,7 +26,8 @@ class TwigPass implements CompilerPassInterface
 
         // Adding setLegacyEngine method call here to avoid side effect in redefining the twig service completely.
         // Mentioned side effects are losing extensions/loaders addition for which method calls are added in the TwigEnvironmentPass
-        $def = $container->getDefinition('twig');
-        $def->addMethodCall('setEzLegacyEngine', array(new Reference('templating.engine.eztpl')));
+        $container->getDefinition('twig')
+            ->setClass('eZ\Publish\Core\MVC\Legacy\Templating\Twig\Environment')
+            ->addMethodCall('setEzLegacyEngine', array(new Reference('templating.engine.eztpl')));
     }
 }

--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;

--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -46,6 +46,9 @@ class Configuration extends SiteAccessConfiguration
     private function addSiteAccessSettings(NodeBuilder $nodeBuilder)
     {
         $nodeBuilder
+            ->booleanNode('not_found_http_conversion')
+                ->info('Whether to use 404 conversion or not. If true, will let symfony handle 404 errors.')
+            ->end()
             ->arrayNode('templating')
                 ->children()
                     ->scalarNode('view_layout')

--- a/bundle/DependencyInjection/Configuration/LegacyConfigResolver.php
+++ b/bundle/DependencyInjection/Configuration/LegacyConfigResolver.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Configuration;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
@@ -101,7 +102,7 @@ class LegacyConfigResolver implements ConfigResolverInterface
     /**
      * Returns values for $groupName, in $namespace.
      *
-     * @param string $groupName String containing an INI group name.
+     * @param string $groupName string containing an INI group name
      * @param string $namespace The legacy INI file name, without the suffix (i.e. without ".ini").
      * @param string $scope A specific siteaccess to look into. Defaults to the current siteaccess.
      *
@@ -137,8 +138,8 @@ class LegacyConfigResolver implements ConfigResolverInterface
      * Checks if $paramName exists in $namespace.
      *
      * @param string $paramName
-     * @param string $namespace If null, the default namespace should be used.
-     * @param string $scope The scope you need $paramName value for.
+     * @param string $namespace if null, the default namespace should be used
+     * @param string $scope the scope you need $paramName value for
      *
      * @return bool
      */

--- a/bundle/DependencyInjection/EzPublishLegacyExtension.php
+++ b/bundle/DependencyInjection/EzPublishLegacyExtension.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ConfigurationProcessor;

--- a/bundle/DependencyInjection/EzPublishLegacyExtension.php
+++ b/bundle/DependencyInjection/EzPublishLegacyExtension.php
@@ -69,6 +69,10 @@ class EzPublishLegacyExtension extends Extension
                     $contextualizer->setContextualParameter('module_default_layout', $currentScope, $scopeSettings['templating']['module_layout']);
                 }
 
+                if (isset($scopeSettings['not_found_http_conversion'])) {
+                    $contextualizer->setContextualParameter('not_found_http_conversion', $currentScope, $scopeSettings['not_found_http_conversion']);
+                }
+
                 if (isset($scopeSettings['legacy_mode'])) {
                     $container = $contextualizer->getContainer();
                     $container->setParameter("ezsettings.$currentScope.legacy_mode", $scopeSettings['legacy_mode']);

--- a/bundle/DependencyInjection/Security/SSOFactory.php
+++ b/bundle/DependencyInjection/Security/SSOFactory.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Security;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory;

--- a/bundle/EventListener/ConfigScopeListener.php
+++ b/bundle/EventListener/ConfigScopeListener.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\EventListener;
 
 use eZ\Publish\Core\MVC\Legacy\Kernel\Loader;

--- a/bundle/EventListener/CsrfTokenResponseListener.php
+++ b/bundle/EventListener/CsrfTokenResponseListener.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\EventListener;
 
 use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse;

--- a/bundle/EventListener/IndexRequestListener.php
+++ b/bundle/EventListener/IndexRequestListener.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\EventListener;
 
 use eZ\Bundle\EzPublishCoreBundle\EventListener\IndexRequestListener as CoreIndexListener;

--- a/bundle/EventListener/LegacyKernelListener.php
+++ b/bundle/EventListener/LegacyKernelListener.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\EventListener;
 
 use eZ\Publish\Core\MVC\Legacy\LegacyEvents;

--- a/bundle/EventListener/RequestListener.php
+++ b/bundle/EventListener/RequestListener.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\EventListener;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;

--- a/bundle/EventListener/RestListener.php
+++ b/bundle/EventListener/RestListener.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;

--- a/bundle/EventListener/SetupListener.php
+++ b/bundle/EventListener/SetupListener.php
@@ -5,6 +5,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;

--- a/bundle/Exception/NotFoundHttpException.php
+++ b/bundle/Exception/NotFoundHttpException.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace eZ\Bundle\EzPublishLegacyBundle\Exception;
+
+use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException as BaseNotFoundHttpException;
+
+class NotFoundHttpException extends BaseNotFoundHttpException
+{
+    /**
+     * @var \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse
+     */
+    protected $originalResponse;
+
+    /**
+     * Constructor.
+     *
+     * @param string $message
+     * @param \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse $originalResponse
+     */
+    public function __construct($message, LegacyResponse $originalResponse = null)
+    {
+        parent::__construct($message);
+
+        $this->originalResponse = $originalResponse;
+    }
+
+    /**
+     * Returns the response.
+     *
+     * @return \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse
+     */
+    public function getOriginalResponse()
+    {
+        return $this->originalResponse;
+    }
+}

--- a/bundle/Exception/NotFoundHttpException.php
+++ b/bundle/Exception/NotFoundHttpException.php
@@ -2,13 +2,13 @@
 
 namespace eZ\Bundle\EzPublishLegacyBundle\Exception;
 
-use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException as BaseNotFoundHttpException;
 
 class NotFoundHttpException extends BaseNotFoundHttpException
 {
     /**
-     * @var \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse
+     * @var \Symfony\Component\HttpFoundation\Response
      */
     protected $originalResponse;
 
@@ -16,9 +16,9 @@ class NotFoundHttpException extends BaseNotFoundHttpException
      * Constructor.
      *
      * @param string $message
-     * @param \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse $originalResponse
+     * @param \Symfony\Component\HttpFoundation\Response $originalResponse
      */
-    public function __construct($message, LegacyResponse $originalResponse = null)
+    public function __construct($message, Response $originalResponse = null)
     {
         parent::__construct($message);
 
@@ -28,7 +28,7 @@ class NotFoundHttpException extends BaseNotFoundHttpException
     /**
      * Returns the response.
      *
-     * @return \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function getOriginalResponse()
     {

--- a/bundle/EzPublishLegacyBundle.php
+++ b/bundle/EzPublishLegacyBundle.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle;
 
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler\RememberMeListenerPass;

--- a/bundle/Features/Context/Admin/Context.php
+++ b/bundle/Features/Context/Admin/Context.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Features\Context\Admin;
 
 use eZ\Bundle\EzPublishLegacyBundle\Features\Context\Legacy;

--- a/bundle/Features/Context/Legacy.php
+++ b/bundle/Features/Context/Legacy.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Features\Context;
 
 use EzSystems\BehatBundle\Context\Browser\Context;

--- a/bundle/Features/Context/SetupWizard/Context.php
+++ b/bundle/Features/Context/SetupWizard/Context.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Features\Context\SetupWizard;
 
 use EzSystems\BehatBundle\Helper\Gherkin as GherkinHelper;

--- a/bundle/FieldType/Image/IO/IOServiceFactory.php
+++ b/bundle/FieldType/Image/IO/IOServiceFactory.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\FieldType\Image\IO;
 
 use eZ\Publish\Core\IO\IOServiceInterface;

--- a/bundle/FieldType/Page/PageService.php
+++ b/bundle/FieldType/Page/PageService.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\FieldType\Page;
 
 use eZ\Bundle\EzPublishCoreBundle\FieldType\Page\PageService as CorePageService;

--- a/bundle/LegacyBundles/LegacyBundleInterface.php
+++ b/bundle/LegacyBundles/LegacyBundleInterface.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\LegacyBundles;
 
 /**

--- a/bundle/LegacyBundles/LegacyExtensionsLocator.php
+++ b/bundle/LegacyBundles/LegacyExtensionsLocator.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\LegacyBundles;
 
 use DirectoryIterator;

--- a/bundle/LegacyBundles/LegacyExtensionsLocatorInterface.php
+++ b/bundle/LegacyBundles/LegacyExtensionsLocatorInterface.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\LegacyBundles;
 
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;

--- a/bundle/LegacyMapper/Configuration.php
+++ b/bundle/LegacyMapper/Configuration.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\LegacyMapper;
 
 use eZ\Publish\Core\FieldType\Image\AliasCleanerInterface;

--- a/bundle/LegacyMapper/LegacyBundles.php
+++ b/bundle/LegacyMapper/LegacyBundles.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\LegacyMapper;
 
 use eZ\Publish\Core\MVC\Legacy\LegacyEvents;

--- a/bundle/LegacyMapper/Security.php
+++ b/bundle/LegacyMapper/Security.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\LegacyMapper;
 
 use eZ\Publish\API\Repository\Repository;

--- a/bundle/LegacyMapper/Session.php
+++ b/bundle/LegacyMapper/Session.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\LegacyMapper;
 
 use eZ\Publish\Core\MVC\Legacy\Event\PreBuildKernelEvent;

--- a/bundle/LegacyMapper/SiteAccess.php
+++ b/bundle/LegacyMapper/SiteAccess.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\LegacyMapper;
 
 use eZ\Publish\Core\MVC\Legacy\LegacyEvents;

--- a/bundle/LegacyResponse.php
+++ b/bundle/LegacyResponse.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle;
 
 use Symfony\Component\HttpFoundation\Response;
@@ -38,7 +39,7 @@ class LegacyResponse extends Response
     /**
      * Gets the module result if it exists.
      *
-     * @return array result or null if it doesn't exist.
+     * @return array result or null if it doesn't exist
      */
     public function getModuleResult()
     {

--- a/bundle/LegacyResponse/LegacyResponseManager.php
+++ b/bundle/LegacyResponse/LegacyResponseManager.php
@@ -14,7 +14,7 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use eZ\Bundle\EzPublishLegacyBundle\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Templating\EngineInterface;
 use DateTime;
@@ -104,13 +104,15 @@ class LegacyResponseManager
                     $errorMessage = isset($moduleResult['errorMessage']) ? $moduleResult['errorMessage'] : 'Access denied';
                     throw new AccessDeniedException($errorMessage);
                 }
-                // If having an "Not found" error code in non-legacy mode and conversation is true,
+
+                // If having an "Not found" error code in non-legacy mode and conversion is true,
                 // we send an NotFoundHttpException to be able to trigger error page in Symfony stack.
                 if ($moduleResult['errorCode'] == 404) {
                     if ($this->notFoundHttpConversion) {
                         $errorMessage = isset($moduleResult['errorMessage']) ? $moduleResult['errorMessage'] : 'Not found';
-                        throw new NotFoundHttpException($errorMessage);
+                        throw new NotFoundHttpException($errorMessage, $response);
                     }
+
                     @trigger_error(
                         "Legacy 404 error handling is deprecated, and will be removed in legacy-bridge 2.0.\n" .
                         'Use the not_found_http_conversion setting to use the new behavior and disable this notice.',

--- a/bundle/LegacyResponse/LegacyResponseManager.php
+++ b/bundle/LegacyResponse/LegacyResponseManager.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\LegacyResponse;
 
 use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse;
@@ -152,7 +153,7 @@ class LegacyResponseManager
     /**
      * Maps headers sent by the legacy stack to $response.
      *
-     * @param array $headers Array headers.
+     * @param array $headers array headers
      * @param \Symfony\Component\HttpFoundation\Response $response
      *
      * @return \Symfony\Component\HttpFoundation\Response
@@ -177,7 +178,7 @@ class LegacyResponseManager
                 case 'expires':
                     $response->setExpires(new DateTime($headerValue));
                     break;
-                default;
+                default:
                     $response->headers->set($headerName, $headerValue, true);
                     break;
             }

--- a/bundle/LegacyResponse/LegacyResponseManager.php
+++ b/bundle/LegacyResponse/LegacyResponseManager.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Templating\EngineInterface;
 use DateTime;
@@ -47,6 +48,13 @@ class LegacyResponseManager
     private $legacyMode;
 
     /**
+     * Flag indicating if we're convert 404 errors into a NotFoundHttpException.
+     *
+     * @var bool
+     */
+    private $notFoundHttpConversion;
+
+    /**
      * @var RequestStack
      */
     private $requestStack;
@@ -55,6 +63,7 @@ class LegacyResponseManager
     {
         $this->templateEngine = $templateEngine;
         $this->legacyLayout = $configResolver->getParameter('module_default_layout', 'ezpublish_legacy');
+        $this->notFoundHttpConversion = $configResolver->getParameter('not_found_http_conversion', 'ezpublish_legacy');
         $this->legacyMode = $configResolver->getParameter('legacy_mode');
         $this->requestStack = $requestStack;
     }
@@ -64,6 +73,7 @@ class LegacyResponseManager
      *
      * @param \ezpKernelResult $result
      *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
      * @return \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse
      */
@@ -87,11 +97,26 @@ class LegacyResponseManager
 
         // Handling error codes sent by the legacy stack
         if (isset($moduleResult['errorCode'])) {
-            // If having an "Unauthorized" or "Forbidden" error code in non-legacy mode,
-            // we send an AccessDeniedException to be able to trigger redirection to login in Symfony stack.
-            if (!$this->legacyMode && ($moduleResult['errorCode'] == 401 || $moduleResult['errorCode'] == 403)) {
-                $errorMessage = isset($moduleResult['errorMessage']) ? $moduleResult['errorMessage'] : 'Access denied';
-                throw new AccessDeniedException($errorMessage);
+            if (!$this->legacyMode) {
+                // If having an "Unauthorized" or "Forbidden" error code in non-legacy mode,
+                // we send an AccessDeniedException to be able to trigger redirection to login in Symfony stack.
+                if ($moduleResult['errorCode'] == 401 || $moduleResult['errorCode'] == 403) {
+                    $errorMessage = isset($moduleResult['errorMessage']) ? $moduleResult['errorMessage'] : 'Access denied';
+                    throw new AccessDeniedException($errorMessage);
+                }
+                // If having an "Not found" error code in non-legacy mode and conversation is true,
+                // we send an NotFoundHttpException to be able to trigger error page in Symfony stack.
+                if ($moduleResult['errorCode'] == 404) {
+                    if ($this->notFoundHttpConversion) {
+                        $errorMessage = isset($moduleResult['errorMessage']) ? $moduleResult['errorMessage'] : 'Not found';
+                        throw new NotFoundHttpException($errorMessage);
+                    }
+                    @trigger_error(
+                        "Legacy 404 error handling is deprecated, and will be removed in legacy-bridge 2.0.\n" .
+                        'Use the not_found_http_conversion setting to use the new behavior and disable this notice.',
+                        E_USER_DEPRECATED
+                    );
+                }
             }
 
             $response->setStatusCode(

--- a/bundle/Resources/config/default_settings.yml
+++ b/bundle/Resources/config/default_settings.yml
@@ -7,4 +7,8 @@ parameters:
     # Pagelayout to use while rendering a content view in legacy
     ezpublish_legacy.default.view_default_layout: EzPublishLegacyBundle::legacy_view_default_pagelayout.html.twig
 
+    # Whether to use 404 conversion or not. If true, will let symfony handle 404 errors.
+    ezpublish_legacy.default.not_found_http_conversion: false
+
+    # Whether to use legacy mode or not. If true, will let the legacy kernel handle url aliases.
     ezsettings.default.legacy_mode: false

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -6,7 +6,6 @@ parameters:
     ezpublish.default_router.legacy_aware_routes: ['_ezpublishLegacyTreeMenu', 'ezpublish_rest_', '_ezpublishPreviewContent', '_wdt', '_profiler', '_assetic']
 
     # Core overrides
-    router.class: eZ\Bundle\EzPublishLegacyBundle\Routing\DefaultRouter
     ezpublish.security.login_listener.class: eZ\Bundle\EzPublishLegacyBundle\Security\SecurityListener
     security.authentication.listener.rememberme.class: eZ\Bundle\EzPublishLegacyBundle\Security\RememberMeListener
 

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -7,7 +7,6 @@ parameters:
 
     # Core overrides
     ezpublish.security.login_listener.class: eZ\Bundle\EzPublishLegacyBundle\Security\SecurityListener
-    security.authentication.listener.rememberme.class: eZ\Bundle\EzPublishLegacyBundle\Security\RememberMeListener
 
     ezpublish_legacy.kernel.lazy_loader.class: eZ\Publish\Core\MVC\Legacy\Kernel\Loader
     ezpublish_legacy.kernel_handler.class: ezpKernelHandler
@@ -95,6 +94,7 @@ services:
             - "@?logger"
         calls:
             - [setContainer, ["@service_container"]]
+            - [setRequestStack, ["@request_stack"]]
 
     ezpublish_legacy.rest.kernel_handler:
         class: "%ezpublish_legacy.kernel_handler.rest.class%"
@@ -173,7 +173,7 @@ services:
             - "@ezpublish.api.service.location"
             - "@security.authorization_checker"
             - "@ezpublish.content_preview_helper"
-            - "@?form.csrf_provider"
+            - "@?security.csrf.token_manager"
 
     ezpublish_legacy.router:
         class: "%ezpublish_legacy.router.class%"

--- a/bundle/Resources/config/templating.yml
+++ b/bundle/Resources/config/templating.yml
@@ -12,7 +12,6 @@ parameters:
     # eZ Template as a real template engine
     templating.engine.eztpl.class: eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine
     assetic.eztpl_formula_loader.class: eZ\Publish\Core\MVC\Legacy\Templating\LegacyFormulaLoader
-    twig.class: eZ\Publish\Core\MVC\Legacy\Templating\Twig\Environment
     twig.loader.string.class: eZ\Publish\Core\MVC\Legacy\Templating\Twig\LoaderString
 
 services:

--- a/bundle/Rest/ResponseWriter.php
+++ b/bundle/Rest/ResponseWriter.php
@@ -2,6 +2,7 @@
 /**
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Rest;
 
 use ezcMvcResultCache;
@@ -10,7 +11,6 @@ use ezcMvcResultStatusObject;
 use ezpKernelRest;
 use ezpKernelResult;
 use ezpRestHttpResponseWriter;
-use Symfony\Component\HttpFoundation\Response;
 
 class ResponseWriter extends ezpRestHttpResponseWriter
 {

--- a/bundle/Routing/DefaultRouter.php
+++ b/bundle/Routing/DefaultRouter.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Routing;
 
 use eZ\Bundle\EzPublishCoreBundle\Routing\DefaultRouter as BaseRouter;

--- a/bundle/Routing/FallbackRouter.php
+++ b/bundle/Routing/FallbackRouter.php
@@ -94,7 +94,7 @@ class FallbackRouter implements RouterInterface, RequestMatcherInterface
      *
      * @param string $name The name of the route
      * @param mixed $parameters An array of parameters
-     * @param bool $absolute Whether to generate an absolute URL
+     * @param int $referenceType The type of reference to be generated (one of the constants)
      *
      * @throws \Symfony\Component\Routing\Exception\RouteNotFoundException
      * @throws \InvalidArgumentException
@@ -103,7 +103,7 @@ class FallbackRouter implements RouterInterface, RequestMatcherInterface
      *
      * @api
      */
-    public function generate($name, $parameters = array(), $absolute = false)
+    public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)
     {
         if ($name === self::ROUTE_NAME) {
             if (!isset($parameters['module_uri'])) {
@@ -113,7 +113,7 @@ class FallbackRouter implements RouterInterface, RequestMatcherInterface
             $moduleUri = $parameters['module_uri'];
             unset($parameters['module_uri']);
 
-            return $this->urlGenerator->generate($moduleUri, $parameters, $absolute);
+            return $this->urlGenerator->generate($moduleUri, $parameters, $referenceType);
         }
 
         throw new RouteNotFoundException();

--- a/bundle/Routing/FallbackRouter.php
+++ b/bundle/Routing/FallbackRouter.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Routing;
 
 use Symfony\Component\Routing\RouterInterface;

--- a/bundle/Routing/UrlGenerator.php
+++ b/bundle/Routing/UrlGenerator.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Routing;
 
 use eZModule;
@@ -61,7 +62,7 @@ class UrlGenerator extends Generator
 
         // Removing siteaccess parameter
         if (isset($parameters['siteaccess'])) {
-            unset($parameters[ 'siteaccess' ]);
+            unset($parameters['siteaccess']);
         }
 
         list($moduleName, $viewName) = explode('/', $legacyModuleUri);

--- a/bundle/Security/RememberMeListener.php
+++ b/bundle/Security/RememberMeListener.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Security;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;

--- a/bundle/Security/SecurityListener.php
+++ b/bundle/Security/SecurityListener.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Security;
 
 use eZ\Publish\Core\MVC\Symfony\Security\EventListener\SecurityListener as BaseListener;

--- a/bundle/SetupWizard/ConfigurationConverter.php
+++ b/bundle/SetupWizard/ConfigurationConverter.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\SetupWizard;
 
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Configuration\LegacyConfigResolver;

--- a/bundle/SetupWizard/ConfigurationDumper.php
+++ b/bundle/SetupWizard/ConfigurationDumper.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\SetupWizard;
 
 use eZ\Publish\Core\MVC\Symfony\ConfigDumperInterface;
@@ -62,7 +63,7 @@ class ConfigurationDumper implements ConfigDumperInterface
     /**
      * Dumps settings contained in $configArray in ezpublish.yml.
      *
-     * @param array $configArray Hash of settings.
+     * @param array $configArray hash of settings
      * @param int $options A binary combination of options. See class OPT_* class constants in {@link \eZ\Publish\Core\MVC\Symfony\ConfigDumperInterface}
      */
     public function dump(array $configArray, $options = ConfigDumperInterface::OPT_DEFAULT)

--- a/bundle/Tests/Cache/PersistenceCachePurgerTest.php
+++ b/bundle/Tests/Cache/PersistenceCachePurgerTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\Cache;
 
 use eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger;
@@ -70,8 +71,8 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::all
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::isAllCleared
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::all
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::isAllCleared
      */
     public function testClearAll()
     {
@@ -85,9 +86,9 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::all
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::resetAllCleared
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::isAllCleared
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::all
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::resetAllCleared
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::isAllCleared
      */
     public function testResetAllCleared()
     {
@@ -99,8 +100,8 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::all
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::content
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::all
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::content
      */
     public function testClearContentAlreadyCleared()
     {
@@ -112,7 +113,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::content
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::content
      */
     public function testClearContentDisabled()
     {
@@ -124,8 +125,8 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::setEnabled
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::all
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::setEnabled
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::all
      */
     public function testClearAllDisabled()
     {
@@ -137,7 +138,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::content
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::content
      */
     public function testClearAllContent()
     {
@@ -154,7 +155,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::content
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::content
      */
     public function testClearContent()
     {
@@ -201,7 +202,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::content
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::content
      */
     public function testClearOneContent()
     {
@@ -248,7 +249,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     /**
      * @expectedException \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
      *
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::content
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::content
      */
     public function testClearContentFail()
     {
@@ -256,7 +257,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::contentType
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::contentType
      */
     public function testClearContentTypeAll()
     {
@@ -269,7 +270,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::contentType
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::contentType
      */
     public function testClearContentType()
     {
@@ -284,7 +285,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     /**
      * @expectedException \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
      *
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::contentType
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::contentType
      */
     public function testClearContentTypeFail()
     {
@@ -292,7 +293,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::contentTypeGroup
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::contentTypeGroup
      */
     public function testClearContentTypeGroupAll()
     {
@@ -312,7 +313,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::contentTypeGroup
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::contentTypeGroup
      */
     public function testClearContentTypeGroup()
     {
@@ -334,7 +335,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     /**
      * @expectedException \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
      *
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::contentTypeGroup
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::contentTypeGroup
      */
     public function testClearContentTypeGroupFail()
     {
@@ -342,7 +343,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::section
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::section
      */
     public function testClearSectionAll()
     {
@@ -355,7 +356,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::section
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::section
      */
     public function testClearSection()
     {
@@ -370,7 +371,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     /**
      * @expectedException \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
      *
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::section
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::section
      */
     public function testClearSectionFail()
     {
@@ -378,7 +379,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::languages
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::languages
      */
     public function testClearLanguages()
     {
@@ -403,7 +404,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::languages
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::languages
      */
     public function testClearOneLanguage()
     {
@@ -424,7 +425,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::user
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::user
      */
     public function testClearUserAll()
     {
@@ -437,7 +438,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::user
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::user
      */
     public function testClearUser()
     {
@@ -452,7 +453,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     /**
      * @expectedException \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
      *
-     * @covers eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::user
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::user
      */
     public function testClearUserFail()
     {

--- a/bundle/Tests/Cache/SwitchableHttpCachePurgerTest.php
+++ b/bundle/Tests/Cache/SwitchableHttpCachePurgerTest.php
@@ -5,6 +5,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\Cache;
 
 use eZ\Bundle\EzPublishLegacyBundle\Cache\SwitchableHttpCachePurger;

--- a/bundle/Tests/Controller/PreviewControllerTest.php
+++ b/bundle/Tests/Controller/PreviewControllerTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\Controller;
 
 use eZ\Bundle\EzPublishLegacyBundle\Controller\PreviewController;

--- a/bundle/Tests/DependencyInjection/Compiler/LegacyBundlesPassTest.php
+++ b/bundle/Tests/DependencyInjection/Compiler/LegacyBundlesPassTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\DependencyInjection\Compiler;
 
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler\LegacyBundlesPass;
@@ -16,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
-class AddFieldTypePassTest extends AbstractCompilerPassTestCase
+class LegacyBundlesPassTest extends AbstractCompilerPassTestCase
 {
     protected $kernelMock;
 

--- a/bundle/Tests/DependencyInjection/Configuration/LegacyConfigResolverTest.php
+++ b/bundle/Tests/DependencyInjection/Configuration/LegacyConfigResolverTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\DependencyInjection\Configuration;
 
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Configuration\LegacyConfigResolver;

--- a/bundle/Tests/DependencyInjection/EzPublishLegacyExtensionTest.php
+++ b/bundle/Tests/DependencyInjection/EzPublishLegacyExtensionTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\DependencyInjection;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;

--- a/bundle/Tests/EventListener/ConfigScopeListenerTest.php
+++ b/bundle/Tests/EventListener/ConfigScopeListenerTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\EventListener;
 
 use eZ\Bundle\EzPublishLegacyBundle\EventListener\ConfigScopeListener;

--- a/bundle/Tests/EventListener/RequestListenerTest.php
+++ b/bundle/Tests/EventListener/RequestListenerTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\EventListener;
 
 use PHPUnit_Framework_TestCase;

--- a/bundle/Tests/EventListener/SetupListenerTest.php
+++ b/bundle/Tests/EventListener/SetupListenerTest.php
@@ -5,6 +5,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\EventListener;
 
 use eZ\Bundle\EzPublishLegacyBundle\EventListener\SetupListener;

--- a/bundle/Tests/FieldType/Page/PageServiceTest.php
+++ b/bundle/Tests/FieldType/Page/PageServiceTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\FieldType\Page;
 
 use eZ\Publish\Core\FieldType\Tests\Page\PageServiceTest as BaseTest;

--- a/bundle/Tests/LegacyBundles/LegacyExtensionsLocatorTest.php
+++ b/bundle/Tests/LegacyBundles/LegacyExtensionsLocatorTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\LegacyBundles;
 
 use eZ\Bundle\EzPublishLegacyBundle\LegacyBundles\LegacyExtensionsLocator;

--- a/bundle/Tests/LegacyMapper/SecurityTest.php
+++ b/bundle/Tests/LegacyMapper/SecurityTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\LegacyMapper;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;

--- a/bundle/Tests/LegacyMapper/SessionTest.php
+++ b/bundle/Tests/LegacyMapper/SessionTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\LegacyMapper;
 
 use eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\Session as SessionMapper;

--- a/bundle/Tests/LegacyResponse/LegacyResponseManagerTest.php
+++ b/bundle/Tests/LegacyResponse/LegacyResponseManagerTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\LegacyResponse;
 
 use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager;
@@ -88,10 +89,10 @@ class LegacyResponseManagerTest extends PHPUnit_Framework_TestCase
      *  - Custom layout provided, module_result presents a "pagelayout" entry
      *  - Legacy mode active, no custom layout.
      *
-     * @param string|null $customLayout Custom Twig layout being used, or null if none.
-     * @param bool $legacyMode Whether legacy mode is active or not.
-     * @param bool $moduleResultLayout Whether if module_result from legacy contains a "pagelayout" entry.
-     * @param bool $isLayoutSetModule Whether current request is using /layout/set/ route.
+     * @param string|null $customLayout custom Twig layout being used, or null if none
+     * @param bool $legacyMode whether legacy mode is active or not
+     * @param bool $moduleResultLayout whether if module_result from legacy contains a "pagelayout" entry
+     * @param bool $isLayoutSetModule whether current request is using /layout/set/ route
      *
      * @dataProvider generateResponseNoCustomLayoutProvider
      */

--- a/bundle/Tests/LegacyResponse/LegacyResponseManagerTest.php
+++ b/bundle/Tests/LegacyResponse/LegacyResponseManagerTest.php
@@ -66,6 +66,51 @@ class LegacyResponseManagerTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @param bool $legacyMode whether legacy mode is active or not
+     * @param bool $notFoundHttpConversion whether not found http conversion is active or not
+     * @param bool $expectException whether exception is expected
+     * @dataProvider generateResponseNotFoundProvider
+     */
+    public function testGenerateResponseNotFound($legacyMode, $notFoundHttpConversion, $expectException)
+    {
+        $this->configResolver
+            ->expects($this->any())
+            ->method('getParameter')
+            ->will(
+                $this->returnValueMap(
+                    array(
+                        array('legacy_mode', null, null, $legacyMode),
+                        array('not_found_http_conversion', 'ezpublish_legacy', null, $notFoundHttpConversion),
+                    )
+                )
+            );
+        if ($expectException) {
+            $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Not found');
+        }
+        $manager = new LegacyResponseManager($this->templateEngine, $this->configResolver, new RequestStack());
+        $content = 'foobar';
+        $moduleResult = array(
+            'content' => $content,
+            'errorCode' => 404,
+            'errorMessage' => 'Not found',
+        );
+        $kernelResult = new ezpKernelResult($content, array('module_result' => $moduleResult));
+        $response = $manager->generateResponseFromModuleResult($kernelResult);
+        if (!$expectException) {
+            $this->assertSame($moduleResult['errorCode'], $response->getStatusCode());
+        }
+    }
+
+    public function generateResponseNotFoundProvider()
+    {
+        return array(
+            array(true, true, false),
+            array(false, true, true),
+            array(false, false, false),
+        );
+    }
+
     public function testLegacyResultHasLayout()
     {
         $requestStack = new RequestStack();

--- a/bundle/Tests/Routing/DefaultRouterTest.php
+++ b/bundle/Tests/Routing/DefaultRouterTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\Routing\DefaultRouterTest;
 
 use eZ\Bundle\EzPublishCoreBundle\Tests\Routing\DefaultRouterTest as BaseTest;

--- a/bundle/Tests/Security/SecurityListenerTest.php
+++ b/bundle/Tests/Security/SecurityListenerTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\Security;
 
 use eZ\Bundle\EzPublishLegacyBundle\Security\SecurityListener;

--- a/bundle/Tests/SetupWizard/ConfigurationConverterTest.php
+++ b/bundle/Tests/SetupWizard/ConfigurationConverterTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\SetupWizard;
 
 use eZ\Publish\Core\MVC\Legacy\Tests\LegacyBasedTestCase;
@@ -170,7 +171,7 @@ class ConfigurationConverterTest extends LegacyBasedTestCase
             'stash' => array(
                 'caches' => array(
                     'default' => array(
-                        'drivers' => array('FileSystem'),// If this fails then APC or Memcached is enabled on PHP-CLI
+                        'drivers' => array('FileSystem'), // If this fails then APC or Memcached is enabled on PHP-CLI
                         'inMemory' => true,
                         'registerDoctrineAdapter' => false,
                     ),

--- a/bundle/Tests/SetupWizard/ConfigurationDumperTest.php
+++ b/bundle/Tests/SetupWizard/ConfigurationDumperTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\SetupWizard;
 
 use eZ\Bundle\EzPublishLegacyBundle\SetupWizard\ConfigurationDumper;

--- a/bundle/Tests/SiteAccess/LegacyMapperTest.php
+++ b/bundle/Tests/SiteAccess/LegacyMapperTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\SiteAccess;
 
 use eZ\Publish\Core\MVC\Legacy\Tests\LegacyBasedTestCase;

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "extra": {
         "ezpublish-legacy-dir": "ezpublish_legacy",
         "branch-alias": {
-            "dev-master": "1.1.x-dev"
+            "dev-master": "1.2.x-dev"
         }
     }
 }

--- a/eZ/Bundle/EzPublishLegacyBundle/Tests/LegacyMapper/SiteAccessTest.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Tests/LegacyMapper/SiteAccessTest.php
@@ -5,6 +5,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\LegacyMapper;
 
 use eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\SiteAccess as SiteAccessMapper;

--- a/mvc/Event/PostBuildKernelEvent.php
+++ b/mvc/Event/PostBuildKernelEvent.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Event;
 
 use Symfony\Component\EventDispatcher\Event;

--- a/mvc/Event/PreBuildKernelEvent.php
+++ b/mvc/Event/PreBuildKernelEvent.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Event;
 
 use Symfony\Component\EventDispatcher\Event;

--- a/mvc/Event/PreBuildKernelWebHandlerEvent.php
+++ b/mvc/Event/PreBuildKernelWebHandlerEvent.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Event;
 
 use Symfony\Component\EventDispatcher\Event;

--- a/mvc/Event/PreResetLegacyKernelEvent.php
+++ b/mvc/Event/PreResetLegacyKernelEvent.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Event;
 
 use eZ\Publish\Core\MVC\Legacy\Kernel as LegacyKernel;

--- a/mvc/EventListener/APIContentExceptionListener.php
+++ b/mvc/EventListener/APIContentExceptionListener.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\EventListener;
 
 use eZ\Publish\Core\MVC\Symfony\Event\APIContentExceptionEvent;

--- a/mvc/Image/AliasCleaner.php
+++ b/mvc/Image/AliasCleaner.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Image;
 
 use eZ\Publish\Core\FieldType\Image\AliasCleanerInterface;

--- a/mvc/Image/AliasGenerator.php
+++ b/mvc/Image/AliasGenerator.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Image;
 
 use eZ\Publish\SPI\Variation\VariationHandler;

--- a/mvc/Kernel.php
+++ b/mvc/Kernel.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy;
 
 use Exception;

--- a/mvc/Kernel/CLIHandler.php
+++ b/mvc/Kernel/CLIHandler.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Kernel;
 
 use ezpKernelHandler;
@@ -45,7 +46,7 @@ class CLIHandler implements ezpKernelHandler
      * Additional valid settings for $settings :
      * - injected-settings : INI settings override
      *
-     * @param array $settings Settings to pass to eZScript constructor.
+     * @param array $settings settings to pass to eZScript constructor
      * @param \eZ\Publish\Core\MVC\Symfony\SiteAccess $siteAccess
      * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
      */

--- a/mvc/Kernel/Loader.php
+++ b/mvc/Kernel/Loader.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Kernel;
 
 use eZ\Publish\Core\MVC\Legacy\Event\PostBuildKernelEvent;
@@ -244,7 +245,7 @@ class Loader
     /**
      * Builds the legacy kernel handler for the tree menu in admin interface.
      *
-     * @return \Closure A closure returning an \ezpKernelTreeMenu instance.
+     * @return \Closure a closure returning an \ezpKernelTreeMenu instance
      */
     public function buildLegacyKernelHandlerTreeMenu()
     {
@@ -260,7 +261,7 @@ class Loader
     /**
      * Builds the legacy kernel handler for the tree menu in admin interface.
      *
-     * @return \Closure A closure returning an \ezpKernelTreeMenu instance.
+     * @return \Closure a closure returning an \ezpKernelTreeMenu instance
      */
     public function buildLegacyKernelHandlerRest($mvcConfiguration)
     {

--- a/mvc/Kernel/Loader.php
+++ b/mvc/Kernel/Loader.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Legacy kernel loader.
@@ -68,6 +69,11 @@ class Loader
     /** @var ezpKernelHandler */
     private $restHandler;
 
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestStack
+     */
+    private $requestStack;
+
     public function __construct($legacyRootDir, $webrootDir, EventDispatcherInterface $eventDispatcher, URIHelper $uriHelper, LoggerInterface $logger = null)
     {
         $this->legacyRootDir = $legacyRootDir;
@@ -75,6 +81,14 @@ class Loader
         $this->eventDispatcher = $eventDispatcher;
         $this->uriHelper = $uriHelper;
         $this->logger = $logger;
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+     */
+    public function setRequestStack(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
     }
 
     /**
@@ -152,7 +166,7 @@ class Loader
 
                 $legacyParameters = new ParameterBag($defaultLegacyOptions);
                 $legacyParameters->set('service-container', $container);
-                $request = $container->get('request');
+                $request = $this->requestStack->getCurrentRequest();
 
                 if ($that->getBuildEventsEnabled()) {
                     // PRE_BUILD_LEGACY_KERNEL for non request related stuff
@@ -277,7 +291,7 @@ class Loader
                 chdir($legacyRootDir);
 
                 $legacyParameters = new ParameterBag();
-                $request = $container->get('request');
+                $request = $this->requestStack->getCurrentRequest();
 
                 if ($that->getBuildEventsEnabled()) {
                     // PRE_BUILD_LEGACY_KERNEL for non request related stuff

--- a/mvc/Kernel/URIHelper.php
+++ b/mvc/Kernel/URIHelper.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Kernel;
 
 use Symfony\Component\HttpFoundation\Request;

--- a/mvc/LegacyEvents.php
+++ b/mvc/LegacyEvents.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy;
 
 final class LegacyEvents

--- a/mvc/LegacyEvents.php
+++ b/mvc/LegacyEvents.php
@@ -25,7 +25,7 @@ final class LegacyEvents
     const PRE_BUILD_LEGACY_KERNEL_WEB = 'ezpublish_legacy.build_kernel_web_handler';
 
     /**
-     * The PRE_BUID_LEGACY_KERNEL occurs right before the build of the legacy handler (whatever the handler is used).
+     * The PRE_BUILD_LEGACY_KERNEL occurs right before the build of the legacy handler (whatever the handler is used).
      * This event allows to inject parameters in the legacy kernel (such as INI settings).
      *
      * The event listener method receives a

--- a/mvc/LegacyKernelAware.php
+++ b/mvc/LegacyKernelAware.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy;
 
 /**

--- a/mvc/Security/Firewall/LoginCleanupListener.php
+++ b/mvc/Security/Firewall/LoginCleanupListener.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Security\Firewall;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;

--- a/mvc/Security/Firewall/SSOListener.php
+++ b/mvc/Security/Firewall/SSOListener.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Security\Firewall;
 
 use eZ\Publish\API\Repository\UserService;

--- a/mvc/Security/LegacyToken.php
+++ b/mvc/Security/LegacyToken.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Security;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/mvc/Session/LegacySessionProxy.php
+++ b/mvc/Session/LegacySessionProxy.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Session;
 
 use Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy;

--- a/mvc/Session/LegacySessionStorage.php
+++ b/mvc/Session/LegacySessionStorage.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Session;
 
 use Symfony\Component\HttpFoundation\Session\SessionBagInterface;

--- a/mvc/SignalSlot/AbstractLegacyObjectStateSlot.php
+++ b/mvc/SignalSlot/AbstractLegacyObjectStateSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;

--- a/mvc/SignalSlot/AbstractLegacySlot.php
+++ b/mvc/SignalSlot/AbstractLegacySlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Slot;

--- a/mvc/SignalSlot/LegacyAssignSectionSlot.php
+++ b/mvc/SignalSlot/LegacyAssignSectionSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
@@ -33,7 +34,7 @@ class LegacyAssignSectionSlot extends AbstractLegacySlot
             function () use ($signal) {
                 eZContentCacheManager::clearContentCacheIfNeeded($signal->contentId);
                 eZSearch::updateObjectsSection(array($signal->contentId), $signal->sectionId);
-                eZContentObject::clearCache();// Clear all object memory cache to free memory
+                eZContentObject::clearCache(); // Clear all object memory cache to free memory
             }
         );
     }

--- a/mvc/SignalSlot/LegacyAssignUserToUserGroupSlot.php
+++ b/mvc/SignalSlot/LegacyAssignUserToUserGroupSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;

--- a/mvc/SignalSlot/LegacyCopyContentSlot.php
+++ b/mvc/SignalSlot/LegacyCopyContentSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
@@ -33,7 +34,7 @@ class LegacyCopyContentSlot extends AbstractLegacySlot
             function () use ($signal) {
                 eZContentCacheManager::clearContentCacheIfNeeded($signal->dstContentId);
                 eZContentOperationCollection::registerSearchObject($signal->dstContentId);
-                eZContentObject::clearCache();// Clear all object memory cache to free memory
+                eZContentObject::clearCache(); // Clear all object memory cache to free memory
             }
         );
     }

--- a/mvc/SignalSlot/LegacyCreateLanguageSlot.php
+++ b/mvc/SignalSlot/LegacyCreateLanguageSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;

--- a/mvc/SignalSlot/LegacyCreateLocationSlot.php
+++ b/mvc/SignalSlot/LegacyCreateLocationSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
@@ -34,7 +35,7 @@ class LegacyCreateLocationSlot extends AbstractLegacySlot
                 eZContentCacheManager::clearContentCacheIfNeeded($signal->contentId, true, array($signal->locationId));
                 $object = eZContentObject::fetch($signal->contentId);
                 eZSearch::addNodeAssignment($object->mainNodeID(), $signal->contentId, $signal->locationId);
-                eZContentObject::clearCache();// Clear all object memory cache to free memory
+                eZContentObject::clearCache(); // Clear all object memory cache to free memory
             }
         );
     }

--- a/mvc/SignalSlot/LegacyCreateObjectStateGroupSlot.php
+++ b/mvc/SignalSlot/LegacyCreateObjectStateGroupSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;

--- a/mvc/SignalSlot/LegacyCreateObjectStateSlot.php
+++ b/mvc/SignalSlot/LegacyCreateObjectStateSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;

--- a/mvc/SignalSlot/LegacyDeleteContentSlot.php
+++ b/mvc/SignalSlot/LegacyDeleteContentSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
@@ -33,7 +34,7 @@ class LegacyDeleteContentSlot extends AbstractLegacySlot
             function () use ($signal) {
                 eZContentCacheManager::clearContentCacheIfNeeded($signal->contentId);
                 eZSearch::removeObjectById($signal->contentId, null);
-                eZContentObject::clearCache();// Clear all object memory cache to free memory
+                eZContentObject::clearCache(); // Clear all object memory cache to free memory
             }
         );
     }

--- a/mvc/SignalSlot/LegacyDeleteLanguageSlot.php
+++ b/mvc/SignalSlot/LegacyDeleteLanguageSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;

--- a/mvc/SignalSlot/LegacyDeleteLocationSlot.php
+++ b/mvc/SignalSlot/LegacyDeleteLocationSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
@@ -45,7 +46,7 @@ class LegacyDeleteLocationSlot extends AbstractLegacySlot
 
                 eZContentCacheManager::clearContentCacheIfNeeded($signal->contentId, true, array($signal->locationId));
                 eZSearch::removeNodes(array($signal->locationId));
-                eZContentObject::clearCache();// Clear all object memory cache to free memory
+                eZContentObject::clearCache(); // Clear all object memory cache to free memory
             }
         );
     }

--- a/mvc/SignalSlot/LegacyDeleteObjectStateGroupSlot.php
+++ b/mvc/SignalSlot/LegacyDeleteObjectStateGroupSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;

--- a/mvc/SignalSlot/LegacyDeleteObjectStateSlot.php
+++ b/mvc/SignalSlot/LegacyDeleteObjectStateSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;

--- a/mvc/SignalSlot/LegacyDeleteVersionSlot.php
+++ b/mvc/SignalSlot/LegacyDeleteVersionSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
@@ -35,7 +36,7 @@ class LegacyDeleteVersionSlot extends AbstractLegacySlot
                 eZContentCacheManager::clearContentCacheIfNeeded($signal->contentId);
                 eZSearch::removeObjectById($signal->contentId, null);
                 eZContentOperationCollection::registerSearchObject($signal->contentId);
-                eZContentObject::clearCache();// Clear all object memory cache to free memory
+                eZContentObject::clearCache(); // Clear all object memory cache to free memory
             }
         );
     }

--- a/mvc/SignalSlot/LegacyDisableLanguageSlot.php
+++ b/mvc/SignalSlot/LegacyDisableLanguageSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;

--- a/mvc/SignalSlot/LegacyEnableLanguageSlot.php
+++ b/mvc/SignalSlot/LegacyEnableLanguageSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;

--- a/mvc/SignalSlot/LegacyHideLocationSlot.php
+++ b/mvc/SignalSlot/LegacyHideLocationSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
@@ -34,7 +35,7 @@ class LegacyHideLocationSlot extends AbstractLegacySlot
                 $node = eZContentObjectTreeNode::fetch($signal->locationId);
                 eZContentObjectTreeNode::clearViewCacheForSubtree($node);
                 eZSearch::updateNodeVisibility($signal->locationId, 'hide');
-                eZContentObject::clearCache();// Clear all object memory cache to free memory
+                eZContentObject::clearCache(); // Clear all object memory cache to free memory
             }
         );
     }

--- a/mvc/SignalSlot/LegacyMoveSubtreeSlot.php
+++ b/mvc/SignalSlot/LegacyMoveSubtreeSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
@@ -34,7 +35,7 @@ class LegacyMoveSubtreeSlot extends AbstractLegacySlot
                 $node = eZContentObjectTreeNode::fetch($signal->locationId);
                 eZContentObjectTreeNode::clearViewCacheForSubtree($node);
                 eZContentOperationCollection::registerSearchObject($node->attribute('contentobject_id'));
-                eZContentObject::clearCache();// Clear all object memory cache to free memory
+                eZContentObject::clearCache(); // Clear all object memory cache to free memory
             }
         );
     }

--- a/mvc/SignalSlot/LegacyPublishContentTypeDraftSlot.php
+++ b/mvc/SignalSlot/LegacyPublishContentTypeDraftSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;

--- a/mvc/SignalSlot/LegacyPublishVersionSlot.php
+++ b/mvc/SignalSlot/LegacyPublishVersionSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
@@ -33,7 +34,7 @@ class LegacyPublishVersionSlot extends AbstractLegacySlot
             function () use ($signal) {
                 eZContentCacheManager::clearContentCacheIfNeeded($signal->contentId);
                 eZContentOperationCollection::registerSearchObject($signal->contentId);
-                eZContentObject::clearCache();// Clear all object memory cache to free memory
+                eZContentObject::clearCache(); // Clear all object memory cache to free memory
             }
         );
     }

--- a/mvc/SignalSlot/LegacySetContentStateSlot.php
+++ b/mvc/SignalSlot/LegacySetContentStateSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
@@ -33,7 +34,7 @@ class LegacySetContentStateSlot extends AbstractLegacySlot
             function () use ($signal) {
                 eZContentCacheManager::clearContentCacheIfNeeded($signal->contentId);
                 eZSearch::updateObjectState($signal->contentId, array($signal->objectStateId));
-                eZContentObject::clearCache();// Clear all object memory cache to free memory
+                eZContentObject::clearCache(); // Clear all object memory cache to free memory
             }
         );
     }

--- a/mvc/SignalSlot/LegacySetPriorityOfObjectStateSlot.php
+++ b/mvc/SignalSlot/LegacySetPriorityOfObjectStateSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;

--- a/mvc/SignalSlot/LegacySwapLocationSlot.php
+++ b/mvc/SignalSlot/LegacySwapLocationSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
@@ -34,7 +35,7 @@ class LegacySwapLocationSlot extends AbstractLegacySlot
                 eZContentCacheManager::clearContentCacheIfNeeded($signal->content1Id);
                 eZContentCacheManager::clearContentCacheIfNeeded($signal->content2Id);
                 eZSearch::swapNode($signal->location1Id, $signal->location2Id);
-                eZContentObject::clearCache();// Clear all object memory cache to free memory
+                eZContentObject::clearCache(); // Clear all object memory cache to free memory
             }
         );
     }

--- a/mvc/SignalSlot/LegacyUnassignUserFromUserGroupSlot.php
+++ b/mvc/SignalSlot/LegacyUnassignUserFromUserGroupSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;

--- a/mvc/SignalSlot/LegacyUnhideLocationSlot.php
+++ b/mvc/SignalSlot/LegacyUnhideLocationSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
@@ -34,7 +35,7 @@ class LegacyUnhideLocationSlot extends AbstractLegacySlot
                 $node = eZContentObjectTreeNode::fetch($signal->locationId);
                 eZContentObjectTreeNode::clearViewCacheForSubtree($node);
                 eZSearch::updateNodeVisibility($signal->locationId, 'show');
-                eZContentObject::clearCache();// Clear all object memory cache to free memory
+                eZContentObject::clearCache(); // Clear all object memory cache to free memory
             }
         );
     }

--- a/mvc/SignalSlot/LegacyUpdateLanguageNameSlot.php
+++ b/mvc/SignalSlot/LegacyUpdateLanguageNameSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;

--- a/mvc/SignalSlot/LegacyUpdateLocationSlot.php
+++ b/mvc/SignalSlot/LegacyUpdateLocationSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
@@ -31,7 +32,7 @@ class LegacyUpdateLocationSlot extends AbstractLegacySlot
         $this->runLegacyKernelCallback(
             function () use ($signal) {
                 eZContentCacheManager::clearContentCacheIfNeeded($signal->contentId);
-                eZContentObject::clearCache();// Clear all object memory cache to free memory
+                eZContentObject::clearCache(); // Clear all object memory cache to free memory
             }
         );
     }

--- a/mvc/SignalSlot/LegacyUpdateObjectStateGroupSlot.php
+++ b/mvc/SignalSlot/LegacyUpdateObjectStateGroupSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;

--- a/mvc/SignalSlot/LegacyUpdateObjectStateSlot.php
+++ b/mvc/SignalSlot/LegacyUpdateObjectStateSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;

--- a/mvc/SignalSlot/LegacyUpdateUserSlot.php
+++ b/mvc/SignalSlot/LegacyUpdateUserSlot.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
@@ -33,7 +34,7 @@ class LegacyUpdateUserSlot extends AbstractLegacySlot
             function () use ($signal) {
                 eZContentCacheManager::clearContentCacheIfNeeded($signal->userId);
                 eZContentOperationCollection::registerSearchObject($signal->userId);
-                eZContentObject::clearCache();// Clear all object memory cache to free memory
+                eZContentObject::clearCache(); // Clear all object memory cache to free memory
             }
         );
     }

--- a/mvc/Templating/Adapter/BlockAdapter.php
+++ b/mvc/Templating/Adapter/BlockAdapter.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Adapter;
 
 use eZ\Publish\Core\FieldType\Page\Parts\Block;
@@ -31,38 +32,38 @@ class BlockAdapter extends DefinitionBasedAdapter
             'overflow_id' => 'overflowId',
             'zone_id' => 'zoneId',
             'valid_items' => function (Block $block) {
-                    return eZFlowPool::validItems($block->id);
-                },
+                return eZFlowPool::validItems($block->id);
+            },
             'valid_nodes' => function (Block $block) {
-                    return eZFlowPool::validNodes($block->id);
-                },
+                return eZFlowPool::validNodes($block->id);
+            },
             'archived_items' => function (Block $block) {
-                    return eZFlowPool::archivedItems($block->id);
-                },
+                return eZFlowPool::archivedItems($block->id);
+            },
             'waiting_items' => function (Block $block) {
-                    return eZFlowPool::waitingItems($block->id);
-                },
+                return eZFlowPool::waitingItems($block->id);
+            },
             'last_valid_items' => function (Block $block) {
-                    $validItems = eZFlowPool::validItems($block->id);
-                    if (empty($validItems)) {
-                        return;
-                    }
+                $validItems = eZFlowPool::validItems($block->id);
+                if (empty($validItems)) {
+                    return;
+                }
 
-                    $result = null;
-                    $lastTime = 0;
-                    foreach ($validItems as $item) {
-                        if ($item->attribute('ts_visible') >= $lastTime) {
-                            $lastTime = $item->attribute('ts_visible');
-                            $result = $item;
-                        }
+                $result = null;
+                $lastTime = 0;
+                foreach ($validItems as $item) {
+                    if ($item->attribute('ts_visible') >= $lastTime) {
+                        $lastTime = $item->attribute('ts_visible');
+                        $result = $item;
                     }
+                }
 
-                    return $result;
-                },
+                return $result;
+            },
             // The following is only for block_view_gui template function in legacy.
             'view_template' => function (Block $block) {
-                    return 'view';
-                },
+                return 'view';
+            },
         );
     }
 }

--- a/mvc/Templating/Adapter/DefinitionBasedAdapter.php
+++ b/mvc/Templating/Adapter/DefinitionBasedAdapter.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Adapter;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/mvc/Templating/Adapter/ValueObjectAdapter.php
+++ b/mvc/Templating/Adapter/ValueObjectAdapter.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Adapter;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\LegacyCompatible;
@@ -31,8 +32,8 @@ class ValueObjectAdapter implements LegacyCompatible
 
     /**
      * @param \eZ\Publish\API\Repository\Values\ValueObject $valueObject The value object to decorate
-     * @param array $attributesMap Hash mapping legacy attribute name (key) to the embedded value object property name (value)
-     *                             Value can also be a closure which would be called directly with the value object as only parameter.
+     * @param array $attributesMap hash mapping legacy attribute name (key) to the embedded value object property name (value)
+     *                             Value can also be a closure which would be called directly with the value object as only parameter
      */
     public function __construct(ValueObject $valueObject, array $attributesMap)
     {

--- a/mvc/Templating/Adapter/ZoneAdapter.php
+++ b/mvc/Templating/Adapter/ZoneAdapter.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Adapter;
 
 use eZ\Publish\Core\FieldType\Page\Parts\Zone;
@@ -30,13 +31,13 @@ class ZoneAdapter extends DefinitionBasedAdapter
             'action' => 'action',
             'zone_identifier' => 'identifier',
             'blocks' => function (Zone $zone) {
-                    $legacyBlocks = array();
-                    foreach ($zone->blocks as $block) {
-                        $legacyBlocks[] = new BlockAdapter($block);
-                    }
+                $legacyBlocks = array();
+                foreach ($zone->blocks as $block) {
+                    $legacyBlocks[] = new BlockAdapter($block);
+                }
 
-                    return $legacyBlocks;
-                },
+                return $legacyBlocks;
+            },
         );
     }
 }

--- a/mvc/Templating/Converter/ApiContentConverter.php
+++ b/mvc/Templating/Converter/ApiContentConverter.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Converter;
 
 use eZ\Publish\API\Repository\Values\Content\Content;

--- a/mvc/Templating/Converter/DelegatingConverter.php
+++ b/mvc/Templating/Converter/DelegatingConverter.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Converter;
 
 class DelegatingConverter implements MultipleObjectConverter

--- a/mvc/Templating/Converter/GenericConverter.php
+++ b/mvc/Templating/Converter/GenericConverter.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Converter;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\LegacyAdapter;

--- a/mvc/Templating/Converter/MultipleObjectConverter.php
+++ b/mvc/Templating/Converter/MultipleObjectConverter.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Converter;
 
 /**

--- a/mvc/Templating/Converter/ObjectConverter.php
+++ b/mvc/Templating/Converter/ObjectConverter.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Converter;
 
 /**

--- a/mvc/Templating/Converter/PagePartsConverter.php
+++ b/mvc/Templating/Converter/PagePartsConverter.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Converter;
 
 use eZ\Publish\Core\FieldType\Page\Parts\Block;

--- a/mvc/Templating/GlobalHelper.php
+++ b/mvc/Templating/GlobalHelper.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating;
 
 use eZ\Publish\Core\MVC\Symfony\Templating\GlobalHelper as BaseGlobalHelper;

--- a/mvc/Templating/LegacyAdapter.php
+++ b/mvc/Templating/LegacyAdapter.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating;
 
 /**
@@ -36,7 +37,7 @@ class LegacyAdapter implements LegacyCompatible
     private $getters;
 
     /**
-     * @param mixed $transferredObject Object being passed to the legacy template.
+     * @param mixed $transferredObject object being passed to the legacy template
      */
     public function __construct($transferredObject)
     {

--- a/mvc/Templating/LegacyCompatible.php
+++ b/mvc/Templating/LegacyCompatible.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating;
 
 /**

--- a/mvc/Templating/LegacyEngine.php
+++ b/mvc/Templating/LegacyEngine.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating;
 
 use Symfony\Component\Templating\EngineInterface;

--- a/mvc/Templating/LegacyFormulaLoader.php
+++ b/mvc/Templating/LegacyFormulaLoader.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating;
 
 use Assetic\Factory\Loader\FormulaLoaderInterface;

--- a/mvc/Templating/LegacyHelper.php
+++ b/mvc/Templating/LegacyHelper.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating;
 
 use Symfony\Component\HttpFoundation\ParameterBag;

--- a/mvc/Templating/Tests/Adapter/DefinitionBasedAdapterTest.php
+++ b/mvc/Templating/Tests/Adapter/DefinitionBasedAdapterTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests\Adapter;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/mvc/Templating/Tests/Adapter/ValueObjectAdapterTest.php
+++ b/mvc/Templating/Tests/Adapter/ValueObjectAdapterTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests\Adapter;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\Adapter\ValueObjectAdapter;
@@ -50,8 +51,8 @@ class ValueObjectAdapterTest extends PHPUnit_Framework_TestCase
             'zone_identifier' => 'identifier',
             'all_blocks' => 'blocks',
             'dynamic_prop' => function (ValueObject $valueObject) {
-                    return $valueObject;
-                },
+                return $valueObject;
+            },
         );
         $this->valueObject = $this
             ->getMockBuilder('eZ\\Publish\\Core\\FieldType\\Page\\Parts\\Zone')
@@ -79,7 +80,7 @@ class ValueObjectAdapterTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider hasAttributeProvider
-     * @covers eZ\Publish\Core\MVC\Legacy\Templating\Adapter\ValueObjectAdapter::hasAttribute
+     * @covers \eZ\Publish\Core\MVC\Legacy\Templating\Adapter\ValueObjectAdapter::hasAttribute
      *
      * @param string$attributeName
      * @param bool $isset
@@ -102,7 +103,7 @@ class ValueObjectAdapterTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Publish\Core\MVC\Legacy\Templating\Adapter\ValueObjectAdapter::attributes
+     * @covers \eZ\Publish\Core\MVC\Legacy\Templating\Adapter\ValueObjectAdapter::attributes
      */
     public function testAttributes()
     {
@@ -110,7 +111,7 @@ class ValueObjectAdapterTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Publish\Core\MVC\Legacy\Templating\Adapter\ValueObjectAdapter::attribute
+     * @covers \eZ\Publish\Core\MVC\Legacy\Templating\Adapter\ValueObjectAdapter::attribute
      */
     public function testGetAttribute()
     {
@@ -138,7 +139,7 @@ class ValueObjectAdapterTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Publish\Core\MVC\Legacy\Templating\Adapter\ValueObjectAdapter::getValueObject
+     * @covers \eZ\Publish\Core\MVC\Legacy\Templating\Adapter\ValueObjectAdapter::getValueObject
      */
     public function testGetValueObject()
     {

--- a/mvc/Templating/Tests/Converter/PagePartsConverterTest.php
+++ b/mvc/Templating/Tests/Converter/PagePartsConverterTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests\Converter;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\Converter\PagePartsConverter;
@@ -16,7 +17,7 @@ class PagePartsConverterTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider convertProvider
-     * @covers eZ\Publish\Core\MVC\Legacy\Templating\Converter\PagePartsConverter::convert
+     * @covers \eZ\Publish\Core\MVC\Legacy\Templating\Converter\PagePartsConverter::convert
      *
      * @param \eZ\Publish\API\Repository\Values\ValueObject $valueObject
      * @param $expectedAdapterClass
@@ -48,9 +49,9 @@ class PagePartsConverterTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @dataProvider convertFailNotObjectProvider
-     * @covers eZ\Publish\Core\MVC\Legacy\Templating\Converter\PagePartsConverter::convert
+     * @covers \eZ\Publish\Core\MVC\Legacy\Templating\Converter\PagePartsConverter::convert
      */
     public function testConvertFailNotObject($value)
     {
@@ -70,8 +71,8 @@ class PagePartsConverterTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers eZ\Publish\Core\MVC\Legacy\Templating\Converter\PagePartsConverter::convert
-     * @expectedException InvalidArgumentException
+     * @covers \eZ\Publish\Core\MVC\Legacy\Templating\Converter\PagePartsConverter::convert
+     * @expectedException \InvalidArgumentException
      */
     public function testConvertFailWrongType()
     {

--- a/mvc/Templating/Tests/GlobalHelperTest.php
+++ b/mvc/Templating/Tests/GlobalHelperTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\GlobalHelper;

--- a/mvc/Templating/Tests/LegacyEngineTest.php
+++ b/mvc/Templating/Tests/LegacyEngineTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine;

--- a/mvc/Templating/Tests/Twig/EnvironmentTest.php
+++ b/mvc/Templating/Tests/Twig/EnvironmentTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests\Twig;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\Twig\Environment;

--- a/mvc/Templating/Tests/Twig/LoaderStringTest.php
+++ b/mvc/Templating/Tests/Twig/LoaderStringTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests\Twig;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\Twig\LoaderString;

--- a/mvc/Templating/Tests/Twig/TemplateTest.php
+++ b/mvc/Templating/Tests/Twig/TemplateTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests\Twig;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\Twig\Template;

--- a/mvc/Templating/Twig/Environment.php
+++ b/mvc/Templating/Twig/Environment.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Twig;
 
 use Twig_Environment;

--- a/mvc/Templating/Twig/Extension/LegacyExtension.php
+++ b/mvc/Templating/Twig/Extension/LegacyExtension.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Twig\Extension;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\LegacyHelper;
@@ -26,13 +27,13 @@ class LegacyExtension extends Twig_Extension implements Twig_Extension_InitRunti
      */
     private $legacyEngine;
 
-    /** @var  \eZ\Publish\Core\MVC\Legacy\Templating\LegacyHelper */
+    /** @var \eZ\Publish\Core\MVC\Legacy\Templating\LegacyHelper */
     private $legacyHelper;
 
-    /** @var  string */
+    /** @var string */
     private $jsTemplate;
 
-    /** @var  string */
+    /** @var string */
     private $cssTemplate;
 
     /**

--- a/mvc/Templating/Twig/LoaderString.php
+++ b/mvc/Templating/Twig/LoaderString.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Twig;
 
 use Twig_LoaderInterface;

--- a/mvc/Templating/Twig/Node/LegacyIncludeNode.php
+++ b/mvc/Templating/Twig/Node/LegacyIncludeNode.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Twig\Node;
 
 use Twig_Node;

--- a/mvc/Templating/Twig/Template.php
+++ b/mvc/Templating/Twig/Template.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Twig;
 
 use Twig_Environment;

--- a/mvc/Templating/Twig/TokenParser/LegacyIncludeParser.php
+++ b/mvc/Templating/Twig/TokenParser/LegacyIncludeParser.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Twig\TokenParser;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\Twig\Node\LegacyIncludeNode;

--- a/mvc/Tests/Event/PostBuildKernelEventTest.php
+++ b/mvc/Tests/Event/PostBuildKernelEventTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Tests\Event;
 
 use eZ\Publish\Core\MVC\Legacy\Event\PostBuildKernelEvent;

--- a/mvc/Tests/Event/PreBuildKernelEventTest.php
+++ b/mvc/Tests/Event/PreBuildKernelEventTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Tests\Event;
 
 use eZ\Publish\Core\MVC\Legacy\Event\PreBuildKernelEvent;

--- a/mvc/Tests/Event/PreBuildKernelWebHandlerEventTest.php
+++ b/mvc/Tests/Event/PreBuildKernelWebHandlerEventTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Tests\Event;
 
 use eZ\Publish\Core\MVC\Legacy\Event\PreBuildKernelWebHandlerEvent;

--- a/mvc/Tests/Image/AliasCleanerTest.php
+++ b/mvc/Tests/Image/AliasCleanerTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Tests\Image;
 
 use eZ\Publish\Core\MVC\Legacy\Image\AliasCleaner;

--- a/mvc/Tests/KernelTest.php
+++ b/mvc/Tests/KernelTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Tests;
 
 use Exception;

--- a/mvc/Tests/LegacyBasedTestCase.php
+++ b/mvc/Tests/LegacyBasedTestCase.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Tests;
 
 use PHPUnit_Framework_TestCase;

--- a/mvc/Tests/Security/SSOListenerTest.php
+++ b/mvc/Tests/Security/SSOListenerTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Tests\Security;
 
 use eZ\Publish\Core\MVC\Legacy\Security\Firewall\SSOListener;

--- a/mvc/Tests/SignalSlot/LegacySlotsTest.php
+++ b/mvc/Tests/SignalSlot/LegacySlotsTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Tests\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot;

--- a/mvc/Tests/URIHelperTest.php
+++ b/mvc/Tests/URIHelperTest.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\Tests;
 
 use eZ\Publish\Core\MVC\Legacy\Kernel\URIHelper;

--- a/mvc/View/Provider.php
+++ b/mvc/View/Provider.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\View;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\LegacyHelper;

--- a/mvc/View/Provider/Block.php
+++ b/mvc/View/Provider/Block.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\View\Provider;
 
 use eZ\Publish\Core\MVC\Legacy\View\Provider;

--- a/mvc/View/Provider/Content.php
+++ b/mvc/View/Provider/Content.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\View\Provider;
 
 use eZ\Publish\Core\FieldType\XmlText\Converter\EmbedToHtml5;

--- a/mvc/View/Provider/Location.php
+++ b/mvc/View/Provider/Location.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\View\Provider;
 
 use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
@@ -88,7 +89,7 @@ class Location extends Provider implements ViewProvider
      * Returns published view for $location.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location
-     * @param string $viewType Variation of display for your content.
+     * @param string $viewType variation of display for your content
      * @param array $params Hash of arbitrary parameters to pass to final view
      * @param \eZ\Publish\Core\MVC\Legacy\Templating\LegacyHelper $legacyHelper
      *

--- a/mvc/View/TwigContentViewLayoutDecorator.php
+++ b/mvc/View/TwigContentViewLayoutDecorator.php
@@ -6,6 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
+
 namespace eZ\Publish\Core\MVC\Legacy\View;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;


### PR DESCRIPTION
Hello,

We're trying to migrate our former sites developed with eZ Publish 5.x in Legacy mode to eZ Platform 6.9.x with LegacyBridge 1.2.x.

I've noticed that the following folder has been moved from eZ Publish 5.x: 
**vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/MVC/Legacy** 
to 
**vendor/ezsystems/legacy-bridge/mvc**

And the method **hasInstance()** has been removed from the class **Kernel.php**.

Could you give us the reason? Is it because it was used for Singleton Pattern which is considered now as an anti-pattern?

And is it possible to reintegrate it again?

The issue is that method is called in the following class: 
**vendor/ezsystems/legacy-bridge/bundle/Collector/TemplateDebugInfo.php**

And other various classes as well.

Thank you in advance for your feedback.

Regards,

Quentin

Here is the method hasInstance extracted from eZ Publish 5.x :

>     /**
>      * Checks if LegacyKernel has already been instantiated.
>      *
>      * @return bool
>      */
>     public static function hasInstance()
>     {
>         return static::$instance !== null;
>     }
