### PR TITLE
EZP 26013 cache update on trash restoration

### DIFF
--- a/bundle/Cache/PersistenceCachePurger.php
+++ b/bundle/Cache/PersistenceCachePurger.php
@@ -152,7 +152,7 @@ class PersistenceCachePurger implements CacheClearerInterface
 
         if ($allContentCacheClearRequired) {
             $this->cache->clear('content');
-            $this->cache->clear('user', 'role', 'assignments', 'byGroup')
+            $this->cache->clear('user', 'role', 'assignments', 'byGroup');
         }
 
         // clear content related cache as well

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -240,7 +240,10 @@ services:
 
     ezpublish_legacy.persistence_cache_purger:
         class: "%ezpublish_legacy.persistence_cache_purger.class%"
-        arguments: ["@ezpublish.cache_pool.spi.cache.decorator", "@ezpublish.spi.persistence.cache.locationHandler", "@logger"]
+        arguments:
+            - "@ezpublish.cache_pool.spi.cache.decorator"
+            - "@ezpublish.spi.persistence.legacy.location.handler"
+            - "@logger"
         tags:
             - { name: kernel.cache_clearer }
         lazy: true

--- a/bundle/Tests/Cache/PersistenceCachePurgerTest.php
+++ b/bundle/Tests/Cache/PersistenceCachePurgerTest.php
@@ -243,7 +243,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test case for https://jira.ez.no/browse/EZP-26013
+     * Test case for https://jira.ez.no/browse/EZP-26013.
      */
     public function testClearNonExistingLocation()
     {

--- a/bundle/Tests/Cache/PersistenceCachePurgerTest.php
+++ b/bundle/Tests/Cache/PersistenceCachePurgerTest.php
@@ -63,6 +63,17 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
             ->method('load')
             ->will($this->throwException(new NotFoundException('location', $id)));
 
+        $cacheItem = $this->getMock('Stash\\Item');
+        $cacheItem->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue(null));
+
+        $this->cacheService
+            ->expects($this->once())
+            ->method('getItem')
+            ->with('location', $id)
+            ->will($this->returnValue($cacheItem));
+
         $this->logger
             ->expects($this->once())
             ->method('notice');

--- a/bundle/Tests/Cache/PersistenceCachePurgerTest.php
+++ b/bundle/Tests/Cache/PersistenceCachePurgerTest.php
@@ -243,6 +243,37 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test case for https://jira.ez.no/browse/EZP-26013
+     */
+    public function testClearNonExistingLocation()
+    {
+        $locationId = 1;
+
+        $this->locationHandler
+            ->expects($this->once())
+            ->method('load')
+            ->will($this->throwException(new NotFoundException('location', $locationId)));
+
+        $this->cacheService
+            ->expects($this->at(1))
+            ->method('clear')
+            ->with('content');
+
+        $cacheItem = $this->getMock('Stash\\Interfaces\\ItemInterface');
+        $cacheItem->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue(null));
+
+        $this->cacheService
+            ->expects($this->once())
+            ->method('getItem')
+            ->with('location', $locationId)
+            ->will($this->returnValue($cacheItem));
+
+        $this->cachePurger->content($locationId);
+    }
+
+    /**
      * @param $locationId
      * @param $contentId
      * @return \eZ\Publish\SPI\Persistence\Content\Location


### PR DESCRIPTION
This is a (possible) fix for https://jira.ez.no/browse/EZP-26013 
This is a fix for https://jira.ez.no/browse/EZP-25240


## Description
For a full story check issue description and my [comment](https://jira.ez.no/browse/EZP-26013?focusedCommentId=211954&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-211954) specificaly.

What we're facing here is that when trying to move item out of trash a [content](https://github.com/ezsystems/LegacyBridge/blob/master/bundle/Cache/PersistenceCachePurger.php#L110) method is called with a set of `locationIds`. One of the ids is locationId (nodeId) of item after restoration from trash, so loading it both from [locationHandler](https://github.com/ezsystems/LegacyBridge/blob/master/bundle/Cache/PersistenceCachePurger.php#L129) fails. 

@pspanja in his [comment](https://jira.ez.no/browse/EZP-26013?focusedCommentId=201574&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-201574) suggested that clearing cache for content in general should help. I tested it and it indeed helps - hence this PR.

I'm not sure if this is only and best solution so I'm hoping for some opinions here