### PR TITLE
Simplify install and add EE support with eZ Platform 1.11 + legacy 2017.08

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ language: php
 
 # run tests on php misc php versions
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - 7.2
 
 cache:
   directories:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,8 +1,9 @@
 # Installing the eZ Platform legacy bridge
 
 Unlike eZ Publish 5.x, eZ Platform does not include the Legacy stack by default.
-Even though it is not officially supported, eZ Publish Legacy can easily be installed
-on top of Platform using Composer.
+
+Even though it is not recommended for use on new installs, eZ Publish Legacy can easily be installed
+on top of Platform using Composer to provide a more up-to-date platform to migrate your code to eZ Platform with.
 
 ### Missing legacy extensions
 
@@ -68,9 +69,7 @@ ezpublish_setup:
 
 ### Install `ezsystems/legacy-bridge`
 
-**Make sure you have set the ezpublish legacy folder in composer.json, as instructed above**
-
-`ezsystems/legacy-bridge` contains the libraries previous included in `ezsystems/ezpublish-kernel`.
+`ezsystems/legacy-bridge` contains the libraries previous included in `ezsystems/ezpublish-kernel` in version 5.x.
 
 It must be installed using Composer. Take care to use `^1.3.0` as version constraint, since previous versions lack some important fixes for newer versions of eZ Platform:
 
@@ -118,4 +117,4 @@ rewrite "^/var/storage/packages/(.*)" "/var/storage/packages/$1" break;
 
 Last step, if you are on *nix operation system, is to make sure to run 
 the appropriate command for setting correct folder permissions, you 
-can find the information you need in installation guide for eZ Publish 5.x.
+can find the information you need in [installation guide for eZ Publish 5.x](https://doc.ez.no/display/EZP/Installation).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -66,40 +66,17 @@ ezpublish_setup:
     security: false
 ```
 
-### Configure ezpublish legacy's location in `composer.json`
-
-`ezsystems/ezpublish-legacy` needs to be installed in a particular location to work.
-
-Edit `composer.json`, and add `"ezpublish-legacy-dir": "ezpublish_legacy"` to the `extra` array:
-
-```
-    "extra": {
-        "ezpublish-legacy-dir": "ezpublish_legacy",
-```
-
 ### Install `ezsystems/legacy-bridge`
 
 **Make sure you have set the ezpublish legacy folder in composer.json, as instructed above**
 
 `ezsystems/legacy-bridge` contains the libraries previous included in `ezsystems/ezpublish-kernel`.
 
-It must be installed using Composer. Take care to use `^1.0.4` as version constraint, since previous versions lack some important fixes for newer versions of eZ Platform:
+It must be installed using Composer. Take care to use `^2.0.0` as version constraint, since previous versions lack some important fixes for newer versions of eZ Platform:
 
 ```
-composer require --update-no-dev "ezsystems/legacy-bridge:^1.0.4"
+composer require --update-no-dev "ezsystems/legacy-bridge:^2.0.0"
 ```
-
-### Configuring Symfony app folder in legacy
-
-In eZ Publish 5, Symfony app folder was named `ezpublish`. This was changed in eZ Platform, and now the folder name is `app`, which is Symfony recommended name. eZ Publish Legacy supports both of these folder names, however, `ezpublish` is still the default one in latest tagged release (v2015.01.3). This means that you need to make eZ Publish Legacy aware of the new folder name. You can do this by using `config.php` file which you can place in `ezpublish_legacy` folder with the following content:
-
-```php
-<?php
-
-define( 'EZP_APP_FOLDER_NAME', 'app' );
-```
-
-If you're using master branch of eZ Publish Legacy, you can skip this step.
 
 ### Configure virtual host rewrite rules
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,7 +69,7 @@ ezpublish_setup:
 
 ### Install `ezsystems/legacy-bridge`
 
-`ezsystems/legacy-bridge` contains the libraries previous included in `ezsystems/ezpublish-kernel` in version 5.x.
+`ezsystems/legacy-bridge` contains the libraries previously included in `ezsystems/ezpublish-kernel` in version 5.x.
 
 It must be installed using Composer. Take care to use `^1.3.0` as version constraint, since previous versions lack some important fixes for newer versions of eZ Platform:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -72,10 +72,10 @@ ezpublish_setup:
 
 `ezsystems/legacy-bridge` contains the libraries previous included in `ezsystems/ezpublish-kernel`.
 
-It must be installed using Composer. Take care to use `^2.0.0` as version constraint, since previous versions lack some important fixes for newer versions of eZ Platform:
+It must be installed using Composer. Take care to use `^1.3.0` as version constraint, since previous versions lack some important fixes for newer versions of eZ Platform:
 
 ```
-composer require --update-no-dev "ezsystems/legacy-bridge:^2.0.0"
+composer require --update-no-dev "ezsystems/legacy-bridge:^1.3.0"
 ```
 
 ### Configure virtual host rewrite rules

--- a/README.md
+++ b/README.md
@@ -12,15 +12,12 @@ It is meant to be installed as an addition to eZ Platform, starting from version
 
 See [INSTALL.md](INSTALL.md) for the installation procedure.
 
-### Roadmap
-
-Legacy Bridge itself is stable and has been in heavy use by most community and eZ customers that have used eZ Publish 5.x series *(Community and Enterprise)*. However, there are a few things on the roadmap, in order of priority:
-
-- A script to reliably automate installation on eZ Platform and eZ Studio to greatly simplify setup to a couple of simple instructions
-- PHP 7 working *(we can't guarantee all extensions will work, but aim is to make sure `ezpublish-legacy` and `LegacyBridge` boots, and work by muting deprecation notices, as already done by eZ in eZ Publish Enterprise v5.4.7 and higher)*
-
-
 ### Reporting issues
 
-As Legacy Bridge is co-maintained by the community and eZ Engineering *(as active community members)*, and not professionally supported by eZ Systems. Issues found should be reported directly here on Github. There is no SLA on fixes, this is all on voluntary basis, and we welcome you in contributing to issues in any form you you are cable of.
+As Legacy Bridge is co-maintained by the community and eZ Engineering *(as active community members)*, issues found can be reported directly here on Github. There is no SLA on fixes, this is all on voluntary basis, and we welcome you in contributing to issues in any form you you are cable of.
 
+
+##### For Enterprise Customers
+
+As of version 1.3.0 you can optionally report issues via [normal support channels](https://support.ez.no) as well where you do have an SLA on response time.
+But as always if you know a possible fix, proposing a PR as well here can speed up the issue identification and fixing a lot so we also encourages eZ Partners to actively participate whenever they can, as it benefits themselves as well as the customer.

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ See [INSTALL.md](INSTALL.md) for the installation procedure.
 
 ### Reporting issues
 
-As Legacy Bridge is co-maintained by the community and eZ Engineering *(as active community members)*, issues found can be reported directly here on Github. There is no SLA on fixes, this is all on voluntary basis, and we welcome you in contributing to issues in any form you you are cable of.
+As Legacy Bridge is co-maintained by the community and eZ Engineering *(as active community members)*, issues found can be reported directly here on Github. There is no SLA on fixes, this is all on voluntary basis, and we welcome you in contributing to issues in any form you you are capable of.
 
 
 ##### For Enterprise Customers
 
 As of version 1.3.0 you can optionally report issues via [normal support channels](https://support.ez.no) as well where you do have an SLA on response time.
-But as always if you know a possible fix, proposing a PR as well here can speed up the issue identification and fixing a lot so we also encourages eZ Partners to actively participate whenever they can, as it benefits themselves as well as the customer.
+But as always if you know a possible fix, proposing a PR as well here can speed up the issue identification and fixing a lot so we encourage eZ Partners to actively participate whenever they can, as it benefits themselves as well as the customer.

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "extra": {
         "ezpublish-legacy-dir": "ezpublish_legacy",
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "1.3.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "ezsystems/ezpublish-legacy-installer": "^2.0.4",
         "ezsystems/ezpublish-legacy": ">=2017.08",
-        "ezsystems/ezpublish-kernel": "~6.0@dev",
+        "ezsystems/ezpublish-kernel": "^6.11@dev",
         "sensio/distribution-bundle": "^3.0.36|^4.0.6|^5.0.6",
         "twig/twig": "^1.27 | ^2.0"
     },
@@ -35,7 +35,7 @@
     "extra": {
         "ezpublish-legacy-dir": "ezpublish_legacy",
         "branch-alias": {
-            "dev-master": "1.2.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "stable",
     "require": {
         "ezsystems/ezpublish-legacy-installer": "^2.0.4",
-        "ezsystems/ezpublish-legacy": ">=2017.07",
+        "ezsystems/ezpublish-legacy": ">=2017.08",
         "ezsystems/ezpublish-kernel": "~6.0@dev",
         "sensio/distribution-bundle": "^3.0.36|^4.0.6|^5.0.6",
         "twig/twig": "^1.27 | ^2.0"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "ezsystems/ezpublish-legacy": ">=2014.11",
+        "ezsystems/ezpublish-legacy-installer": "^2.0.4",
+        "ezsystems/ezpublish-legacy": ">=2017.07",
         "ezsystems/ezpublish-kernel": "~6.0@dev",
         "sensio/distribution-bundle": "^3.0.36|^4.0.6|^5.0.6",
         "twig/twig": "^1.27 | ^2.0"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "stable",
     "require": {
         "ezsystems/ezpublish-legacy-installer": "^2.0.4",
-        "ezsystems/ezpublish-legacy": ">=2017.08",
+        "ezsystems/ezpublish-legacy": ">=2017.08@dev",
         "ezsystems/ezpublish-kernel": "^6.11@dev",
         "sensio/distribution-bundle": "^3.0.36|^4.0.6|^5.0.6",
         "twig/twig": "^1.27 | ^2.0"


### PR DESCRIPTION
Proposal for a ~~2.0.0~~ `1.3.0` release of legacy bridge, with aim to simplify installation. Implied in this simplification is also the need to provide a new legacy kernel release for use by community as well as potentially also eZ Enterprise users*. 

There might also be other things that can be simplified, suggestions (PR's) welcome :)


 \* _Afaik 5.4 legacy can't have features found in the 2017.08 milestone below needed for eZ Platform compatibility, and we don't intend to do a 5.5 release._ 


Bumps:
- legacy installer: in order to skip install step about defining `ezpublish-legacy-dir`
- legacy kernel: to be able to skip install steps about setting `EZP_APP_FOLDER_NAME`
- eZ Platform kernel _(ezpublish-kernel)_:  for future parity with 2017.08 legacy kernel
  - _Note: some of these features depends on community contributions, and might not make it._

TODO:
- [ ] Finalize and release legacy kernel [2017.08](https://github.com/ezsystems/ezpublish-legacy/milestone/1) and corresponding eZ Platform v1.11 release
