### PR TITLE
Fix EZEE-1656: Clarify that the legacy routes should be added at the end of the `app/config/routing` file

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,7 +37,7 @@ the `$bundles` array. Pay close attention to the `$this` argument. The LegacyBun
 of a spoiled brat, and has high expectations from its collaborators.
 
 ### Add legacy routes
-Edit `app/config/routing.yml`, and add the LegacyBundle routes.
+Edit `app/config/routing.yml`, and add the LegacyBundle routes at the end of the file.
 
 ```
 _ezpublishLegacyRoutes:


### PR DESCRIPTION
Related JIRA ticket: [EZEE-1656](https://jira.ez.no/browse/EZEE-1656)

Currently it is not specified where the legacy routes should be added to the `app/config/routing` file. If they are added before `_ezpublishDateBasedPublisher`, then the issue described in the JIRA ticket happens. To make sure it doesn't, the installation instructions should be clear that the legacy routes should be added after `_ezpublishDateBasedPublisher`.
For simplicity, I changed the installation instruction so it recommends adding the legacy routes at the end of the `app/config/routing` file.