### PR TITLE
Simplify install for 1.2 branch

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -78,6 +78,11 @@ It must be installed using Composer. Take care to use `^1.0.4` as version constr
 composer require --update-no-dev "ezsystems/legacy-bridge:^1.0.4"
 ```
 
+Alternatively, for eZ Platform EE users you should make sure to use the latest 5.4 version of legacy to receive full support:
+```
+composer require --update-with-dependencies "ezsystems/ezpublish-legacy:5.4.10" "ezsystems/legacy-bridge:^1.0.4"
+```
+
 ### Configuring Symfony app folder in legacy
 
 _Step not needed with version >= 5.4.7 (ee) and >= 2016.10 (community forks)_.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,7 +85,7 @@ composer require --update-with-dependencies "ezsystems/ezpublish-legacy:5.4.10" 
 
 ### Configuring Symfony app folder in legacy
 
-_Step not needed with version >= 5.4.7 (ee) and >= 2016.10 (community forks)_.
+_Step not needed with version >= 5.4.7 (ee) and >= 2016.10_.
 
 In eZ Publish 5, Symfony app folder was named `ezpublish`. This was changed in eZ Platform, and now the folder name is `app`, which is Symfony recommended name. eZ Publish Legacy supports both of these folder names, however, `ezpublish` is still the default one in latest tagged release (v2015.01.3). This means that you need to make eZ Publish Legacy aware of the new folder name. You can do this by using `config.php` file which you can place in `ezpublish_legacy` folder with the following content:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,20 +68,7 @@ ezpublish_setup:
     security: false
 ```
 
-### Configure ezpublish legacy's location in `composer.json`
-
-`ezsystems/ezpublish-legacy` needs to be installed in a particular location to work.
-
-Edit `composer.json`, and add `"ezpublish-legacy-dir": "ezpublish_legacy"` to the `extra` array:
-
-```
-    "extra": {
-        "ezpublish-legacy-dir": "ezpublish_legacy",
-```
-
 ### Install `ezsystems/legacy-bridge`
-
-**Make sure you have set the ezpublish legacy folder in composer.json, as instructed above**
 
 `ezsystems/legacy-bridge` contains the libraries previous included in `ezsystems/ezpublish-kernel`.
 
@@ -92,6 +79,8 @@ composer require --update-no-dev "ezsystems/legacy-bridge:^1.0.4"
 ```
 
 ### Configuring Symfony app folder in legacy
+
+_Step not needed with version >= 5.4.7 (ee) and >= 2016.10 (community forks)_.
 
 In eZ Publish 5, Symfony app folder was named `ezpublish`. This was changed in eZ Platform, and now the folder name is `app`, which is Symfony recommended name. eZ Publish Legacy supports both of these folder names, however, `ezpublish` is still the default one in latest tagged release (v2015.01.3). This means that you need to make eZ Publish Legacy aware of the new folder name. You can do this by using `config.php` file which you can place in `ezpublish_legacy` folder with the following content:
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "ezsystems/ezpublish-legacy": ">=2014.11",
+        "ezsystems/ezpublish-legacy-installer": "^2.0.4",
+        "ezsystems/ezpublish-legacy": "^5.4.10|>=2014.11",
         "ezsystems/ezpublish-kernel": "~6.0@dev",
         "sensio/distribution-bundle": "^3.0.36|^4.0.6|^5.0.6",
         "twig/twig": "^1.27 | ^2.0"


### PR DESCRIPTION
- Bumps requirements to legacy-installer 2.0.4 & gets rid of instruction to configure legacy dir
- Updates kernel and legacy requirements so 1.3 will be needed for 6.11 / 2017.08 (#98)
- Add a cleaner note on how to install with 5.4 legacy then what was proposed in #102