### PR TITLE
EZP-27795: Notice thrown when declaring empty HTTP headers in Legacy

### DIFF
--- a/bundle/LegacyResponse/LegacyResponseManager.php
+++ b/bundle/LegacyResponse/LegacyResponseManager.php
@@ -188,9 +188,9 @@ class LegacyResponseManager
     public function mapHeaders(array $headers, Response $response)
     {
         foreach ($headers as $header) {
-            $headerArray = explode(': ', $header, 2);
+            $headerArray = explode(':', $header, 2);
             $headerName = strtolower($headerArray[0]);
-            $headerValue = $headerArray[1];
+            $headerValue = trim($headerArray[1]);
             // Removing existing header to avoid duplicate values
             $this->removeHeader($headerName);
 

--- a/bundle/Tests/LegacyResponse/LegacyResponseManagerTest.php
+++ b/bundle/Tests/LegacyResponse/LegacyResponseManagerTest.php
@@ -297,4 +297,17 @@ class LegacyResponseManagerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(new DateTime($dateForCache), $responseMappedHeaders->getLastModified());
         $this->assertEquals(new DateTime($dateForCache), $responseMappedHeaders->getExpires());
     }
+
+    public function testEmptyHeaderValueShouldNotRaiseNotice()
+    {
+        $manager = $this->getMockBuilder('eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager')
+            ->setConstructorArgs(array($this->templateEngine, $this->configResolver, new RequestStack()))
+            ->setMethods(array('removeHeader'))
+            ->getMock();
+        /** @var \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager|\PHPUnit_Framework_MockObject_MockObject $manager */
+        $headers = array('X-Foo: Bar', 'Pragma:');
+        $response = new LegacyResponse();
+
+        $manager->mapHeaders($headers, $response);
+    }
 }


### PR DESCRIPTION
JIRA issue: [https://jira.ez.no/browse/EZP-27795](https://jira.ez.no/browse/EZP-27795)

# Description
When a user creates own empty HTTP header (for e.g. *Pragma:*) using Legacy stack then notice `Undefined offset: 1` were thrown. This PR fixes this issue.