### PR TITLE
[Feature] Add command to setup legacy settings/designs symlinks

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@ Edit `composer.json`, and add those lines to both `post-update-cmd` and `post-in
         "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installAssets",
         "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installLegacyBundlesExtensions",
         "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::generateAutoloads",
-        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::symlinkLegacySrcFiles"
+        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::symlinkLegacyFiles"
     ],
     "post-install-cmd": [
         ...,

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,8 +7,8 @@ on top of Platform using Composer to provide a more up-to-date platform to migra
 
 ### Add the composer `legacy post-*-scripts`
 
-Edit `composer.json`, and add those lines to both `post-update-cmd` and `post-install-cmd` blocks at the end:
-
+Edit `composer.json`, and add those lines to both `post-update-cmd` and `post-install-cmd` blocks at the end, but before
+`eZ\Bundle\EzPublishCoreBundle\Composer\ScriptHandler::dumpAssets`:
 ```
 "scripts": {
     "legacy-scripts": [
@@ -27,6 +27,34 @@ Edit `composer.json`, and add those lines to both `post-update-cmd` and `post-in
     ],
 }
 ```
+
+Example: In the case of stock eZ Platform 1.11 and higher that would specifically be:
+```
+"scripts": {
+    "legacy-scripts": [
+        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installAssets",
+        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installLegacyBundlesExtensions",
+        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::generateAutoloads",
+        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::symlinkLegacyFiles"
+    ],
+    "symfony-scripts": [
+        "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
+        "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
+        "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::clearCache",
+        "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
+        "@legacy-scripts"
+        "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::dumpAssets",
+        "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
+    ],
+    "post-install-cmd": [
+        "@symfony-scripts"
+    ],
+    "post-update-cmd": [
+        "@symfony-scripts"
+    ],
+    (...)
+```
+
 
 ### Enable EzPublishLegacyBundle
 Edit `app/AppKernel.php`, and add `new eZ\Bundle\EzPublishLegacyBundle\EzPublishLegacyBundle( $this ),`

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,17 +11,19 @@ Edit `composer.json`, and add those lines to both `post-update-cmd` and `post-in
 
 ```
 "scripts": {
-    "post-install-cmd": [
-        ...,
+    "legacy-scripts": [
         "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installAssets",
         "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installLegacyBundlesExtensions",
-        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::generateAutoloads"
+        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::generateAutoloads",
+        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::symlinkLegacySrcFiles"
+    ],
+    "post-install-cmd": [
+        ...,
+        "@legacy-scripts"
     ],
     "post-update-cmd": [
         ...,
-        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installAssets",
-        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installLegacyBundlesExtensions",
-        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::generateAutoloads"
+        "@legacy-scripts"
     ],
 }
 ```

--- a/bundle/Command/LegacyBundleInstallCommand.php
+++ b/bundle/Command/LegacyBundleInstallCommand.php
@@ -29,8 +29,8 @@ class LegacyBundleInstallCommand extends ContainerAwareCommand
             ->setDescription('Installs legacy extensions (default: symlink) defined in Symfony bundles into ezpublish_legacy/extensions')
             ->setHelp(
                 <<<EOT
-The command <info>%command.name%</info> installs <info>legacy extensions</info> stored in a Symfony 2 bundle
-into the ezpublish_legacy folder.
+The command <info>%command.name%</info> installs <info>legacy extensions</info> stored in a Symfony bundle
+into the ezpublish_legacy/extension folder.
 EOT
             );
     }

--- a/bundle/Command/LegacySrcSymlinkCommand.php
+++ b/bundle/Command/LegacySrcSymlinkCommand.php
@@ -63,7 +63,7 @@ EOT
 Aborting: The src directory "$srcArg" does not exist.
 
 You can create the directory by running <info>ezpublish:legacy:symlink -c</info>, OR by creating the folders you need
-manually among the once supported by this command:
+manually among the ones supported by this command:
 - $srcArg/design
 - $srcArg/settings/override
 - $srcArg/settings/siteaccess
@@ -93,7 +93,7 @@ EOT
         if ($symlinkFolderStr) {
             $output->writeln("The following folders where symlinked: '$symlinkFolderStr'.");
         } else {
-            $output->writeln('No folders where symlinked, use force option if they need to be re-created.');
+            $output->writeln('No folders where symlinked, use <info>--force</info> option if they need to be re-created.');
         }
 
         $output->writeln(<<<EOT

--- a/bundle/Command/LegacySrcSymlinkCommand.php
+++ b/bundle/Command/LegacySrcSymlinkCommand.php
@@ -36,7 +36,7 @@ The command <info>%command.name%</info> setups and symlinks <info>src/legacy_fil
 any design/settings project files, and symlinks these into <info>ezpublish_legacy/</info> which is installed by composer.
 
 The benefit of this is:
-1. Being able to version your design/config files in git withouth versing legacy itself
+1. Being able to version your design/config files in git without versioning legacy itself
 2. A predefined convention for where to place these files when migrating from older versions
 3. Placing these files directly in ezpublish_legacy folder will lead to them getting removed in some cases when composer
    needs to completely replace ezpublish-legacy package for different reasons.

--- a/bundle/Command/LegacySrcSymlinkCommand.php
+++ b/bundle/Command/LegacySrcSymlinkCommand.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * File containing the LegacySrcSymlinkCommand class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+class LegacySrcSymlinkCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('ezpublish:legacy:symlink_src')
+            ->setDefinition(
+                array(
+                    new InputArgument('src', InputArgument::OPTIONAL, 'The src directory for legacy files', 'src/legacy_files'),
+                )
+            )
+            ->addOption('create', 'c', InputOption::VALUE_NONE, 'Create src folder structure if it does not exists')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Symlink folders even if target already exists')
+            ->setDescription('Installs legacy project settings and design files from "src" to corresponding folders in ezpublish_legacy/')
+            ->setHelp(
+                <<<EOT
+The command <info>%command.name%</info> setups and symlinks <info>src/legacy_files</info> stored in your root project for
+any design/settings project files, and symlinks these into <info>ezpublish_legacy/</info> which is installed by composer.
+
+<comment>NOTE: Look towards 'ezpublish:legacybundles:install_extensions' command for how you handle extensions.</comment>
+EOT
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $srcArg = rtrim($input->getArgument('src'), '/');
+        $create = (bool)$input->getOption('create');
+        $force = (bool)$input->getOption('force');
+
+        /**
+         * @var \Symfony\Component\Filesystem\Filesystem
+         */
+        $filesystem = $this->getContainer()->get('filesystem');
+
+        if (!$filesystem->exists($srcArg)) {
+            if ($create) {
+                $this->createSrcFolderStructure($filesystem, $srcArg);
+                $output->writeln("<comment>Empty legacy src folder was created in '$srcArg'.</comment>");
+                // No break, continue so setup symlink settings/override
+            } else {
+                throw new \InvalidArgumentException(sprintf('The src directory "%s" does not exist.', $srcArg));
+            }
+        }
+
+        $symlinkFolderStr = implode(' ,', $this->linkSrcFolders($filesystem, $srcArg, $force));
+
+        if ($symlinkFolderStr) {
+            $output->writeln("The following folders where symlinked: '$symlinkFolderStr'.");
+        } else {
+            $output->writeln('No folders where symlinked, use force option if they need to be re-created.');
+        }
+
+        $output->writeln(<<<EOT
+
+If you create or move additional design or siteaccess folders to '$srcArg' from previous install, then
+re-run <info>ezpublish:legacy:symlink_src</info> to setup symlinks to eZ Publish legacy folder for them also.
+
+EOT
+);
+    }
+
+    /**
+     * Create legacy src folder structure.
+     *
+     * src/legacy_files:
+     * - design
+     * - settings:
+     *   - override
+     *   - siteaccess
+     *
+     * @param Filesystem $filesystem
+     * @param string $srcArg
+     */
+    protected function createSrcFolderStructure(Filesystem $filesystem, $srcArg)
+    {
+        $filesystem->mkdir([
+            $srcArg,
+            "$srcArg/design",
+            "$srcArg/settings",
+            "$srcArg/settings/override",
+            "$srcArg/settings/siteaccess",
+        ]);
+    }
+
+    /**
+     * Setup symlinks for legacy settings/design files within eZ Publish legacy folder.
+     *
+     * @param Filesystem $filesystem
+     * @param string $srcArg
+     * @param bool $force
+     *
+     * @return array
+     */
+    protected function linkSrcFolders(Filesystem $filesystem, $srcArg, $force)
+    {
+        $symlinks = [];
+        $legacyRootDir = rtrim($this->getContainer()->getParameter('ezpublish_legacy.root_dir'), '/');
+
+        if ($force || !$filesystem->exists("$legacyRootDir/settings/override")) {
+            $filesystem->symlink(
+                $filesystem->makePathRelative(
+                    realpath("$srcArg/settings/override"),
+                    realpath("$legacyRootDir/settings")
+                ),
+                "$legacyRootDir/settings/override"
+            );
+            $symlinks[] = "$legacyRootDir/settings/override";
+        }
+
+        $directories = ['design', 'settings/override'];
+        foreach ($directories as $directory) {
+            foreach (Finder::create()->directories()->in(["$srcArg/$directory"]) as $folder) {
+                $folderName = $folder->getFilename();
+                if (!$force && $filesystem->exists("$legacyRootDir/$directory/$folderName")) {
+                    continue;
+                }
+
+                $filesystem->symlink(
+                    $filesystem->makePathRelative(
+                        realpath("$srcArg/$directory/$folderName"),
+                        realpath("$legacyRootDir/$directory")
+                    ),
+                    "$legacyRootDir/$directory/$folderName"
+                );
+                $symlinks[] = "$legacyRootDir/$directory/$folderName";
+            }
+        }
+
+        return $symlinks;
+    }
+}

--- a/bundle/Composer/ScriptHandler.php
+++ b/bundle/Composer/ScriptHandler.php
@@ -39,15 +39,11 @@ class ScriptHandler extends DistributionBundleScriptHandler
             $symlink = '--symlink --relative ';
         }
 
-        if (!is_dir($appDir)) {
-            echo 'The symfony-app-dir (' . $appDir . ') specified in composer.json was not found in ' . getcwd() . ', can not install assets.' . PHP_EOL;
-
+        if (!self::isDir($appDir, 'symfony-app-dir')) {
             return;
         }
 
-        if (!is_dir($webDir)) {
-            echo 'The symfony-web-dir (' . $webDir . ') specified in composer.json was not found in ' . getcwd() . ', can not install assets.' . PHP_EOL;
-
+        if (!self::isDir($webDir, 'symfony-web-dir')) {
             return;
         }
 
@@ -64,9 +60,7 @@ class ScriptHandler extends DistributionBundleScriptHandler
             $symlink = '--relative ';
         }
 
-        if (!is_dir($appDir)) {
-            echo 'The symfony-app-dir (' . $appDir . ') specified in composer.json was not found in ' . getcwd() . ', can not install assets.' . PHP_EOL;
-
+        if (!self::isDir($appDir, 'symfony-app-dir')) {
             return;
         }
 
@@ -78,9 +72,7 @@ class ScriptHandler extends DistributionBundleScriptHandler
         $options = self::getOptions($event);
         $appDir = $options['symfony-app-dir'];
 
-        if (!is_dir($appDir)) {
-            echo 'The symfony-app-dir (' . $appDir . ') specified in composer.json was not found in ' . getcwd() . ', can not generate autoloads.' . PHP_EOL;
-
+        if (!self::isDir($appDir, 'symfony-app-dir')) {
             return;
         }
 
@@ -92,12 +84,40 @@ class ScriptHandler extends DistributionBundleScriptHandler
         $options = self::getOptions($event);
         $appDir = $options['symfony-app-dir'];
 
-        if (!is_dir($appDir)) {
-            echo 'The symfony-app-dir (' . $appDir . ') specified in composer.json was not found in ' . getcwd() . ', can not generate kernel override autoloads.' . PHP_EOL;
-
+        if (!self::isDir($appDir, 'symfony-app-dir')) {
             return;
         }
 
         static::executeCommand($event, $appDir, 'ezpublish:legacy:script bin/php/ezpgenerateautoloads.php -o');
+    }
+
+    public static function symlinkLegacySrcFiles(Event $event)
+    {
+        $options = self::getOptions($event);
+        $appDir = $options['symfony-app-dir'];
+
+        $srcFolder = '';
+        if (isset($options['legacy-src-folder'])) {
+            $srcFolder = $options['legacy-src-folder'];
+        }
+
+        if (!self::isDir($appDir, 'symfony-app-dir')) {
+            return;
+        }
+
+        static::executeCommand($event, $appDir, 'ezpublish:legacy:symlink_src -c ' . $srcFolder);
+    }
+
+    private static function isDir($dir, $composerSetting)
+    {
+        if (is_dir($dir)) {
+            return true;
+        }
+
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+        echo "The ${composerSetting} (${dir}) specified in composer.json was not found in " . getcwd();
+        echo ', can not execute: ' . $trace[0]['function'] . PHP_EOL;
+
+        return false;
     }
 }

--- a/bundle/Composer/ScriptHandler.php
+++ b/bundle/Composer/ScriptHandler.php
@@ -91,7 +91,7 @@ class ScriptHandler extends DistributionBundleScriptHandler
         static::executeCommand($event, $appDir, 'ezpublish:legacy:script bin/php/ezpgenerateautoloads.php -o');
     }
 
-    public static function symlinkLegacySrcFiles(Event $event)
+    public static function symlinkLegacyFiles(Event $event)
     {
         $options = self::getOptions($event);
         $appDir = $options['symfony-app-dir'];
@@ -105,7 +105,7 @@ class ScriptHandler extends DistributionBundleScriptHandler
             return;
         }
 
-        static::executeCommand($event, $appDir, 'ezpublish:legacy:symlink_src -c ' . $srcFolder);
+        static::executeCommand($event, $appDir, 'ezpublish:legacy:symlink -c ' . $srcFolder);
     }
 
     private static function isDir($dir, $composerSetting)

--- a/bundle/Composer/ScriptHandler.php
+++ b/bundle/Composer/ScriptHandler.php
@@ -105,7 +105,7 @@ class ScriptHandler extends DistributionBundleScriptHandler
             return;
         }
 
-        static::executeCommand($event, $appDir, 'ezpublish:legacy:symlink -c ' . $srcFolder);
+        static::executeCommand($event, $appDir, 'ezpublish:legacy:symlink ' . $srcFolder);
     }
 
     private static function isDir($dir, $composerSetting)


### PR DESCRIPTION
> This is done for doc effort in: https://github.com/ezsystems/developer-documentation/pull/28
> Which is from issue: https://jira.ez.no/browse/EZP-27142
> Part of Epic: https://jira.ez.no/browse/EZEE-1455

Without this feature, each and every user would have to find out the hard way that
Composer sometimes wipes out the `ezpublish_legacy` folder, and also that versioning
this folder is not really recommended so you somehow need to deal with settings and designs.

So this command setups and symlinks the following into legacy on compser install and update:
- src/legacy_files:
  - designs/*
  - settings/override
  - settings/siteaccess/*

The feature in this PR is primary aiming at upgrade/migration use cases, where
people are coming from 5.4 or 2014.x and similar and need to move over settings and designs.

Review wanted from partners that have their own way of doing this, as you will know
better what you need. /cc @emodric @joekepley @peterkeung ..

### Why no extension folder handling?
Extensions are handled by composer, and also by legacy bundles command by this bundle,
so if you need an extension in src folder you can make app bundle a legacy bundle.
Hence it felt easily confusing to give another option for this.

### Why no storage and storage/packages folder handling?
As site storage folder is not typically versioned in git, I guess this should be handled by something else then `src/`. Input on how people tend to deal with this is more then welcome!

### Why place them directly in `src/legacy_files`?
Opted for this mainly because placing it in bundle is more of a legacy bundles feature, and also makes sure we are forward compatible with Symfony 4/Flex's single bundle src layout.