### PR TITLE
Upgraded PHPUnit to 5.7

### DIFF
--- a/bundle/Tests/Cache/PersistenceCachePurgerTest.php
+++ b/bundle/Tests/Cache/PersistenceCachePurgerTest.php
@@ -11,10 +11,13 @@ namespace eZ\Bundle\EzPublishLegacyBundle\Tests\Cache;
 
 use eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger;
 use eZ\Publish\SPI\Persistence\Content\Location;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
-use PHPUnit_Framework_TestCase;
+use eZ\Publish\Core\Persistence\Cache\CacheServiceDecorator;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
-class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
+class PersistenceCachePurgerTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
@@ -40,12 +43,12 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
         $this->cacheService = $this
-            ->getMockBuilder('eZ\\Publish\\Core\\Persistence\\Cache\\CacheServiceDecorator')
+            ->getMockBuilder(CacheServiceDecorator::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->locationHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
-        $this->logger = $this->getMock('Psr\\Log\\LoggerInterface');
+        $this->locationHandler = $this->createMock(Handler::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
 
         $this->cachePurger = new PersistenceCachePurger(
             $this->cacheService, $this->locationHandler, $this->logger

--- a/bundle/Tests/Cache/PersistenceCachePurgerTest.php
+++ b/bundle/Tests/Cache/PersistenceCachePurgerTest.php
@@ -42,11 +42,7 @@ class PersistenceCachePurgerTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->cacheService = $this
-            ->getMockBuilder(CacheServiceDecorator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $this->cacheService = $this->createMock(CacheServiceDecorator::class);
         $this->locationHandler = $this->createMock(Handler::class);
         $this->logger = $this->createMock(LoggerInterface::class);
 

--- a/bundle/Tests/Cache/SwitchableHttpCachePurgerTest.php
+++ b/bundle/Tests/Cache/SwitchableHttpCachePurgerTest.php
@@ -9,9 +9,10 @@
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\Cache;
 
 use eZ\Bundle\EzPublishLegacyBundle\Cache\SwitchableHttpCachePurger;
-use PHPUnit_Framework_TestCase;
+use eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger;
+use PHPUnit\Framework\TestCase;
 
-class SwitchableHttpCachePurgerTest extends PHPUnit_Framework_TestCase
+class SwitchableHttpCachePurgerTest extends TestCase
 {
     /** @var \eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger|\PHPUnit_Framework_MockObject_MockObject */
     private $gatewayCachePurgerMock;
@@ -21,7 +22,7 @@ class SwitchableHttpCachePurgerTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->gatewayCachePurgerMock = $this->getMock('eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger');
+        $this->gatewayCachePurgerMock = $this->createMock(GatewayCachePurger::class);
         $this->httpCachePurger = new SwitchableHttpCachePurger($this->gatewayCachePurgerMock);
     }
 

--- a/bundle/Tests/Controller/PreviewControllerTest.php
+++ b/bundle/Tests/Controller/PreviewControllerTest.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\MVC\Symfony\Controller\Tests\Controller\Content\PreviewControllerTest as BasePreviewControllerTest;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 
 class PreviewControllerTest extends BasePreviewControllerTest
 {
@@ -25,7 +26,7 @@ class PreviewControllerTest extends BasePreviewControllerTest
     protected function setUp()
     {
         parent::setUp();
-        $this->configResolver = $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
     }
 
     /**

--- a/bundle/Tests/DependencyInjection/Compiler/LegacyBundlesPassTest.php
+++ b/bundle/Tests/DependencyInjection/Compiler/LegacyBundlesPassTest.php
@@ -66,7 +66,7 @@ class LegacyBundlesPassTest extends AbstractCompilerPassTestCase
     protected function getKernelMock()
     {
         if (!isset($this->kernelMock)) {
-            $this->kernelMock = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
+            $this->kernelMock = $this->createMock(KernelInterface::class);
         }
 
         return $this->kernelMock;
@@ -77,7 +77,7 @@ class LegacyBundlesPassTest extends AbstractCompilerPassTestCase
      */
     protected function createBundleMock($name)
     {
-        $mock = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $mock = $this->createMock(BundleInterface::class);
         $mock
             ->expects($this->any())
             ->method('getName')
@@ -92,7 +92,7 @@ class LegacyBundlesPassTest extends AbstractCompilerPassTestCase
     protected function getLocatorMock()
     {
         if (!isset($this->locatorMock)) {
-            $this->locatorMock = $this->getMock('eZ\Bundle\EzPublishLegacyBundle\LegacyBundles\LegacyExtensionsLocatorInterface');
+            $this->locatorMock = $this->createMock(LegacyExtensionsLocatorInterface::class);
         }
 
         return $this->locatorMock;

--- a/bundle/Tests/DependencyInjection/Configuration/LegacyConfigResolverTest.php
+++ b/bundle/Tests/DependencyInjection/Configuration/LegacyConfigResolverTest.php
@@ -10,10 +10,11 @@
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\DependencyInjection\Configuration;
 
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Configuration\LegacyConfigResolver;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Exception\ParameterNotFoundException;
+use ezpKernelHandler;
 
-class LegacyConfigResolverTest extends PHPUnit_Framework_TestCase
+class LegacyConfigResolverTest extends TestCase
 {
     const DEFAULT_NAMESPACE = 'site';
 
@@ -30,7 +31,7 @@ class LegacyConfigResolverTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $legacyKernel = $this->legacyKernel = $this->getMock('ezpKernelHandler');
+        $legacyKernel = $this->legacyKernel = $this->createMock(ezpKernelHandler::class);
         $kernelClosure = function () use ($legacyKernel) {
             return $legacyKernel;
         };

--- a/bundle/Tests/EventListener/ConfigScopeListenerTest.php
+++ b/bundle/Tests/EventListener/ConfigScopeListenerTest.php
@@ -43,8 +43,6 @@ class ConfigScopeListenerTest extends TestCase
 
     private function getKernelLoaderMock()
     {
-        return $this->getMockBuilder(Loader::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(Loader::class);
     }
 }

--- a/bundle/Tests/EventListener/ConfigScopeListenerTest.php
+++ b/bundle/Tests/EventListener/ConfigScopeListenerTest.php
@@ -12,10 +12,11 @@ namespace eZ\Bundle\EzPublishLegacyBundle\Tests\EventListener;
 use eZ\Bundle\EzPublishLegacyBundle\EventListener\ConfigScopeListener;
 use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use eZ\Publish\Core\MVC\Legacy\Kernel\Loader;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ConfigScopeListenerTest extends PHPUnit_Framework_TestCase
+class ConfigScopeListenerTest extends TestCase
 {
     public function testGetSubscribedEvents()
     {
@@ -42,7 +43,7 @@ class ConfigScopeListenerTest extends PHPUnit_Framework_TestCase
 
     private function getKernelLoaderMock()
     {
-        return $this->getMockBuilder('eZ\Publish\Core\MVC\Legacy\Kernel\Loader')
+        return $this->getMockBuilder(Loader::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/bundle/Tests/EventListener/RequestListenerTest.php
+++ b/bundle/Tests/EventListener/RequestListenerTest.php
@@ -85,10 +85,7 @@ class RequestListenerTest extends TestCase
             ->with($apiUser);
 
         $session = $this->createMock(SessionInterface::class);
-        $request = $this->getMockBuilder(Request::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getSession'])
-            ->getMock();
+        $request = $this->createMock(Request::class);
         $request
             ->expects($this->any())
             ->method('getSession')

--- a/bundle/Tests/EventListener/SetupListenerTest.php
+++ b/bundle/Tests/EventListener/SetupListenerTest.php
@@ -11,11 +11,14 @@ namespace eZ\Bundle\EzPublishLegacyBundle\Tests\EventListener;
 use eZ\Bundle\EzPublishLegacyBundle\EventListener\SetupListener;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\RequestContext;
+use PHPUnit\Framework\TestCase;
 
-class SetupListenerTest extends \PHPUnit_Framework_TestCase
+class SetupListenerTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\Routing\RouterInterface
@@ -25,7 +28,7 @@ class SetupListenerTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $this->router = $this->createMock(RouterInterface::class);
     }
 
     public function testSubscribedEvents()
@@ -67,7 +70,7 @@ class SetupListenerTest extends \PHPUnit_Framework_TestCase
         $this->router
             ->expects($this->once())
             ->method('getContext')
-            ->will($this->returnValue($this->getMock('Symfony\Component\Routing\RequestContext')));
+            ->will($this->returnValue($this->createMock(RequestContext::class)));
 
         $event = $this->createEvent('/setup');
         $this->getListener('setup')->onKernelRequestSetup($event);
@@ -84,14 +87,14 @@ class SetupListenerTest extends \PHPUnit_Framework_TestCase
         $this->router
             ->expects($this->once())
             ->method('getContext')
-            ->will($this->returnValue($this->getMock('Symfony\Component\Routing\RequestContext')));
+            ->will($this->returnValue($this->createMock(RequestContext::class)));
 
         $event = $this->createEvent('/foo/bar');
         $this->getListener('setup')->onKernelRequestSetup($event);
         $this->assertTrue($event->hasResponse());
         /** @var RedirectResponse $response */
         $response = $event->getResponse();
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame('/setup', $response->getTargetUrl());
     }
 
@@ -102,7 +105,7 @@ class SetupListenerTest extends \PHPUnit_Framework_TestCase
     private function createEvent($uri = null, $requestType = HttpKernelInterface::MASTER_REQUEST)
     {
         return new GetResponseEvent(
-            $this->getMock('Symfony\\Component\\HttpKernel\\HttpKernelInterface'),
+            $this->createMock(HttpKernelInterface::class),
             $uri !== null ? Request::create($uri) : new Request(),
             $requestType
         );

--- a/bundle/Tests/FieldType/Page/PageServiceTest.php
+++ b/bundle/Tests/FieldType/Page/PageServiceTest.php
@@ -10,10 +10,11 @@
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\FieldType\Page;
 
 use eZ\Publish\Core\FieldType\Tests\Page\PageServiceTest as BaseTest;
+use eZ\Bundle\EzPublishLegacyBundle\FieldType\Page\PageService;
 
 class PageServiceTest extends BaseTest
 {
-    const PAGESERVICE_CLASS = 'eZ\\Bundle\\EzPublishLegacyBundle\\FieldType\\Page\\PageService';
+    const PAGESERVICE_CLASS = PageService::class;
 
     protected function getZoneDefinition()
     {

--- a/bundle/Tests/LegacyBundles/LegacyExtensionsLocatorTest.php
+++ b/bundle/Tests/LegacyBundles/LegacyExtensionsLocatorTest.php
@@ -10,11 +10,12 @@
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\LegacyBundles;
 
 use eZ\Bundle\EzPublishLegacyBundle\LegacyBundles\LegacyExtensionsLocator;
-use Mockery;
+use eZ\Bundle\EzPublishLegacyBundle\LegacyBundles\LegacyBundleInterface;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use org\bovigo\vfs\vfsStream;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class LegacyExtensionsLocatorTest extends PHPUnit_Framework_TestCase
+class LegacyExtensionsLocatorTest extends TestCase
 {
     /** @var \org\bovigo\vfs\vfsStreamDirectory */
     private $vfsRoot;
@@ -49,16 +50,15 @@ class LegacyExtensionsLocatorTest extends PHPUnit_Framework_TestCase
 
     public function testGetExtensionsNames()
     {
-        $bundle = Mockery::mock(
-            'eZ\Bundle\EzPublishLegacyBundle\LegacyBundles\LegacyBundleInterface,' .
-            'Symfony\Component\HttpKernel\Bundle\BundleInterface'
-        );
-        $bundle
-            ->shouldReceive('getPath')
-            ->andReturn(vfsStream::url('eZ/TestBundle/'));
-        $bundle
-            ->shouldReceive('getLegacyExtensionsNames')
-            ->andReturn(array('extension3'));
+        $bundle = $this->createMock([LegacyBundleInterface::class, BundleInterface::class]);
+
+        $bundle->expects($this->once())
+            ->method('getPath')
+            ->willReturn(vfsStream::url('eZ/TestBundle/'));
+
+        $bundle->expects($this->once())
+            ->method('getLegacyExtensionsNames')
+            ->willReturn(array('extension3'));
 
         $locator = new LegacyExtensionsLocator($this->vfsRoot);
 

--- a/bundle/Tests/LegacyMapper/SecurityTest.php
+++ b/bundle/Tests/LegacyMapper/SecurityTest.php
@@ -17,9 +17,9 @@ use eZ\Publish\Core\Repository\Values\User\User;
 use eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\Security;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class SecurityTest extends PHPUnit_Framework_TestCase
+class SecurityTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\API\Repository\Repository

--- a/bundle/Tests/LegacyMapper/SecurityTest.php
+++ b/bundle/Tests/LegacyMapper/SecurityTest.php
@@ -9,15 +9,25 @@
 
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\LegacyMapper;
 
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\MVC\Legacy\Event\PostBuildKernelEvent;
 use eZ\Publish\Core\MVC\Legacy\Event\PreBuildKernelWebHandlerEvent;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Legacy\LegacyEvents;
+use eZ\Publish\Core\MVC\Legacy\Kernel;
 use eZ\Publish\Core\Repository\Values\User\User;
 use eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\Security;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use PHPUnit\Framework\TestCase;
+use ezpKernelHandler;
+use ezpWebBasedKernelHandler;
 
 class SecurityTest extends TestCase
 {
@@ -44,10 +54,10 @@ class SecurityTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->repository = $this->getMock('eZ\Publish\API\Repository\Repository');
-        $this->configResolver = $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
-        $this->tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
-        $this->authChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        $this->repository = $this->createMock(Repository::class);
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+        $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $this->authChecker = $this->createMock(AuthorizationCheckerInterface::class);
     }
 
     public function testGetSubscribedEvents()
@@ -63,9 +73,9 @@ class SecurityTest extends TestCase
 
     public function testOnKernelBuiltNotWebBasedHandler()
     {
-        $kernelHandler = $this->getMock('ezpKernelHandler');
+        $kernelHandler = $this->createMock(ezpKernelHandler::class);
         $legacyKernel = $this
-            ->getMockBuilder('eZ\Publish\Core\MVC\Legacy\Kernel')
+            ->getMockBuilder(Kernel::class)
             ->setConstructorArgs(array($kernelHandler, 'foo', 'bar'))
             ->getMock();
         $event = new PostBuildKernelEvent($legacyKernel, $kernelHandler);
@@ -83,9 +93,9 @@ class SecurityTest extends TestCase
 
     public function testOnKernelBuiltWithLegacyMode()
     {
-        $kernelHandler = $this->getMock('ezpWebBasedKernelHandler');
+        $kernelHandler = $this->createMock(ezpWebBasedKernelHandler::class);
         $legacyKernel = $this
-            ->getMockBuilder('eZ\Publish\Core\MVC\Legacy\Kernel')
+            ->getMockBuilder(Kernel::class)
             ->setConstructorArgs(array($kernelHandler, 'foo', 'bar'))
             ->getMock();
         $event = new PostBuildKernelEvent($legacyKernel, $kernelHandler);
@@ -108,9 +118,9 @@ class SecurityTest extends TestCase
 
     public function testOnKernelBuiltDisabled()
     {
-        $kernelHandler = $this->getMock('ezpWebBasedKernelHandler');
+        $kernelHandler = $this->createMock(ezpWebBasedKernelHandler::class);
         $legacyKernel = $this
-            ->getMockBuilder('eZ\Publish\Core\MVC\Legacy\Kernel')
+            ->getMockBuilder(Kernel::class)
             ->setConstructorArgs(array($kernelHandler, 'foo', 'bar'))
             ->getMock();
         $event = new PostBuildKernelEvent($legacyKernel, $kernelHandler);
@@ -129,9 +139,9 @@ class SecurityTest extends TestCase
 
     public function testOnKerneBuiltNotAuthenticated()
     {
-        $kernelHandler = $this->getMock('ezpWebBasedKernelHandler');
+        $kernelHandler = $this->createMock(ezpWebBasedKernelHandler::class);
         $legacyKernel = $this
-            ->getMockBuilder('eZ\Publish\Core\MVC\Legacy\Kernel')
+            ->getMockBuilder(Kernel::class)
             ->setConstructorArgs(array($kernelHandler, 'foo', 'bar'))
             ->getMock();
         $event = new PostBuildKernelEvent($legacyKernel, $kernelHandler);
@@ -146,7 +156,7 @@ class SecurityTest extends TestCase
             ->method('getToken')
             ->will(
                 $this->returnValue(
-                    $this->getMock('\Symfony\Component\Security\Core\Authentication\Token\TokenInterface')
+                    $this->createMock(TokenInterface::class)
                 )
             );
         $this->authChecker
@@ -167,9 +177,9 @@ class SecurityTest extends TestCase
 
     public function testOnKernelBuilt()
     {
-        $kernelHandler = $this->getMock('ezpWebBasedKernelHandler');
+        $kernelHandler = $this->createMock(ezpWebBasedKernelHandler::class);
         $legacyKernel = $this
-            ->getMockBuilder('eZ\Publish\Core\MVC\Legacy\Kernel')
+            ->getMockBuilder(Kernel::class)
             ->setConstructorArgs(array($kernelHandler, 'foo', 'bar'))
             ->getMock();
         $event = new PostBuildKernelEvent($legacyKernel, $kernelHandler);
@@ -184,7 +194,7 @@ class SecurityTest extends TestCase
             ->method('getToken')
             ->will(
                 $this->returnValue(
-                    $this->getMock('\Symfony\Component\Security\Core\Authentication\Token\TokenInterface')
+                    $this->createMock(TokenInterface::class)
                 )
             );
         $this->authChecker
@@ -215,12 +225,12 @@ class SecurityTest extends TestCase
      */
     private function generateUser($userId)
     {
-        $versionInfo = $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\Content\VersionInfo');
+        $versionInfo = $this->getMockForAbstractClass(VersionInfo::class);
         $versionInfo
             ->expects($this->any())
             ->method('getContentInfo')
             ->will($this->returnValue(new ContentInfo(array('id' => $userId))));
-        $content = $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\Content\Content');
+        $content = $this->getMockForAbstractClass(Content::class);
         $content
             ->expects($this->any())
             ->method('getVersionInfo')

--- a/bundle/Tests/LegacyMapper/SessionTest.php
+++ b/bundle/Tests/LegacyMapper/SessionTest.php
@@ -12,11 +12,14 @@ namespace eZ\Bundle\EzPublishLegacyBundle\Tests\LegacyMapper;
 use eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\Session as SessionMapper;
 use eZ\Publish\Core\MVC\Legacy\Event\PreBuildKernelEvent;
 use eZ\Publish\Core\MVC\Legacy\LegacyEvents;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
-class SessionTest extends PHPUnit_Framework_TestCase
+class SessionTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
@@ -41,10 +44,10 @@ class SessionTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->sessionStorage = $this->getMock('Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface');
-        $this->session = $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $this->sessionStorage = $this->createMock(SessionStorageInterface::class);
+        $this->session = $this->createMock(SessionInterface::class);
         $this->request = $this
-            ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->getMockBuilder(Request::class)
             ->setMethods(array('hasPreviousSession'))
             ->getMock();
         $this->requestStack = new RequestStack();

--- a/bundle/Tests/LegacyMapper/SiteAccessTest.php
+++ b/bundle/Tests/LegacyMapper/SiteAccessTest.php
@@ -11,10 +11,12 @@ namespace eZ\Bundle\EzPublishLegacyBundle\Tests\LegacyMapper;
 use eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\SiteAccess as SiteAccessMapper;
 use eZ\Publish\Core\MVC\Legacy\Event\PreBuildKernelWebHandlerEvent;
 use eZSiteAccess;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class SiteAccessTest extends PHPUnit_Framework_TestCase
+class SiteAccessTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\HttpFoundation\Request
@@ -31,7 +33,7 @@ class SiteAccessTest extends PHPUnit_Framework_TestCase
         $this->systemErrorLevel = error_reporting(E_ALL & ~E_DEPRECATED);
 
         $this->request = $this
-            ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->getMockBuilder(Request::class)
             ->setMethods(['getPathInfo'])
             ->getMock();
     }
@@ -108,7 +110,7 @@ class SiteAccessTest extends PHPUnit_Framework_TestCase
             ->setConstructorArgs(['Admin', eZSiteAccess::TYPE_URI, null])
             ->getMock();
 
-        $containerMock = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $containerMock = $this->createMock(ContainerInterface::class);
         $containerMock
             ->expects($this->once())
             ->method('get')

--- a/bundle/Tests/LegacyMapper/SiteAccessTest.php
+++ b/bundle/Tests/LegacyMapper/SiteAccessTest.php
@@ -106,7 +106,6 @@ class SiteAccessTest extends TestCase
             ->method('getPathInfo')
             ->will($this->returnValue($pathInfo));
 
-
         $siteAccess = $this
             ->getMockBuilder(SiteAccess::class)
             ->setConstructorArgs(['Admin', eZSiteAccess::TYPE_URI, null])

--- a/bundle/Tests/LegacyMapper/SiteAccessTest.php
+++ b/bundle/Tests/LegacyMapper/SiteAccessTest.php
@@ -10,6 +10,7 @@ namespace eZ\Bundle\EzPublishLegacyBundle\Tests\LegacyMapper;
 
 use eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\SiteAccess as SiteAccessMapper;
 use eZ\Publish\Core\MVC\Legacy\Event\PreBuildKernelWebHandlerEvent;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZSiteAccess;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -105,8 +106,9 @@ class SiteAccessTest extends TestCase
             ->method('getPathInfo')
             ->will($this->returnValue($pathInfo));
 
+
         $siteAccess = $this
-            ->getMockBuilder('eZ\Publish\Core\MVC\Symfony\SiteAccess')
+            ->getMockBuilder(SiteAccess::class)
             ->setConstructorArgs(['Admin', eZSiteAccess::TYPE_URI, null])
             ->getMock();
 

--- a/bundle/Tests/LegacyResponse/LegacyResponseManagerTest.php
+++ b/bundle/Tests/LegacyResponse/LegacyResponseManagerTest.php
@@ -48,7 +48,7 @@ class LegacyResponseManagerTest extends TestCase
     public function testGenerateResponseAccessDenied($errorCode, $errorMessage)
     {
         $this->expectException(AccessDeniedException::class);
-        if (!is_null($errorMessage)) {
+        if (null !== $errorMessage) {
             $this->expectExceptionMessage($errorMessage);
         }
 

--- a/bundle/Tests/LegacyResponse/LegacyResponseManagerTest.php
+++ b/bundle/Tests/LegacyResponse/LegacyResponseManagerTest.php
@@ -12,15 +12,18 @@ namespace eZ\Bundle\EzPublishLegacyBundle\Tests\LegacyResponse;
 use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager;
 use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
-use PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Templating\EngineInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use ezpKernelResult;
 use ezpKernelRedirect;
 use DateTime;
+use PHPUnit\Framework\TestCase;
 
-class LegacyResponseManagerTest extends PHPUnit_Framework_TestCase
+class LegacyResponseManagerTest extends TestCase
 {
     /**
      * @var EngineInterface|\PHPUnit_Framework_MockObject_MockObject
@@ -35,8 +38,8 @@ class LegacyResponseManagerTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->templateEngine = $this->getMock('Symfony\Component\Templating\EngineInterface');
-        $this->configResolver = $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
+        $this->templateEngine = $this->createMock(EngineInterface::class);
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
     }
 
     /**
@@ -44,7 +47,11 @@ class LegacyResponseManagerTest extends PHPUnit_Framework_TestCase
      */
     public function testGenerateResponseAccessDenied($errorCode, $errorMessage)
     {
-        $this->setExpectedException('Symfony\Component\Security\Core\Exception\AccessDeniedException', $errorMessage);
+        $this->expectException(AccessDeniedException::class);
+        if (!is_null($errorMessage)) {
+            $this->expectExceptionMessage($errorMessage);
+        }
+
         $manager = new LegacyResponseManager($this->templateEngine, $this->configResolver, new RequestStack());
         $content = 'foobar';
         $moduleResult = array(
@@ -86,7 +93,8 @@ class LegacyResponseManagerTest extends PHPUnit_Framework_TestCase
                 )
             );
         if ($expectException) {
-            $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Not found');
+            $this->expectException(NotFoundHttpException::class);
+            $this->expectExceptionMessage('Not found');
         }
         $manager = new LegacyResponseManager($this->templateEngine, $this->configResolver, new RequestStack());
         $content = 'foobar';
@@ -178,7 +186,7 @@ class LegacyResponseManagerTest extends PHPUnit_Framework_TestCase
         $kernelResult = new ezpKernelResult($content, array('module_result' => $moduleResult));
 
         $response = $manager->generateResponseFromModuleResult($kernelResult);
-        $this->assertInstanceOf('eZ\Bundle\EzPublishLegacyBundle\LegacyResponse', $response);
+        $this->assertInstanceOf(LegacyResponse::class, $response);
         $this->assertSame($content, $response->getContent());
         $this->assertSame($moduleResult['errorCode'], $response->getStatusCode());
     }
@@ -230,7 +238,7 @@ class LegacyResponseManagerTest extends PHPUnit_Framework_TestCase
         $kernelResult = new ezpKernelResult($content, array('module_result' => $moduleResult));
 
         $response = $manager->generateResponseFromModuleResult($kernelResult);
-        $this->assertInstanceOf('eZ\Bundle\EzPublishLegacyBundle\LegacyResponse', $response);
+        $this->assertInstanceOf(LegacyResponse::class, $response);
         $this->assertSame($contentWithLayout, $response->getContent());
         $this->assertSame($moduleResult['errorCode'], $response->getStatusCode());
         $this->assertSame($moduleResult, $response->getModuleResult());
@@ -258,7 +266,7 @@ class LegacyResponseManagerTest extends PHPUnit_Framework_TestCase
         $manager = new LegacyResponseManager($this->templateEngine, $this->configResolver, new RequestStack());
         $response = $manager->generateRedirectResponse($kernelRedirect);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame($uri, $response->getTargetUrl());
         $this->assertSame($expectedStatusCode, $response->getStatusCode());
     }
@@ -281,7 +289,7 @@ class LegacyResponseManagerTest extends PHPUnit_Framework_TestCase
         $headers = array('X-Foo: Bar', "Etag: $etag", "Last-Modified: $dateForCache", "Expires: $dateForCache");
 
         // Partially mock the manager to simulate calls to header_remove()
-        $manager = $this->getMockBuilder('eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager')
+        $manager = $this->getMockBuilder(LegacyResponseManager::class)
             ->setConstructorArgs(array($this->templateEngine, $this->configResolver, new RequestStack()))
             ->setMethods(array('removeHeader'))
             ->getMock();
@@ -300,7 +308,7 @@ class LegacyResponseManagerTest extends PHPUnit_Framework_TestCase
 
     public function testEmptyHeaderValueShouldNotRaiseNotice()
     {
-        $manager = $this->getMockBuilder('eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager')
+        $manager = $this->getMockBuilder(LegacyResponseManager::class)
             ->setConstructorArgs(array($this->templateEngine, $this->configResolver, new RequestStack()))
             ->setMethods(array('removeHeader'))
             ->getMock();

--- a/bundle/Tests/Routing/DefaultRouterTest.php
+++ b/bundle/Tests/Routing/DefaultRouterTest.php
@@ -11,12 +11,13 @@ namespace eZ\Bundle\EzPublishLegacyBundle\Tests\Routing\DefaultRouterTest;
 
 use eZ\Bundle\EzPublishCoreBundle\Tests\Routing\DefaultRouterTest as BaseTest;
 use Symfony\Component\HttpFoundation\Request;
+use eZ\Bundle\EzPublishLegacyBundle\Routing\DefaultRouter;
 
 class DefaultRouterTest extends BaseTest
 {
     protected function getRouterClass()
     {
-        return 'eZ\Bundle\EzPublishLegacyBundle\Routing\DefaultRouter';
+        return DefaultRouter::class;
     }
 
     /**

--- a/bundle/Tests/Security/SecurityListenerTest.php
+++ b/bundle/Tests/Security/SecurityListenerTest.php
@@ -31,7 +31,7 @@ class SecurityListenerTest extends BaseTest
     public function testOnKernelRequestLegacyMode()
     {
         $event = new GetResponseEvent(
-            $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock(HttpKernelInterface::class),
             new Request(),
             HttpKernelInterface::MASTER_REQUEST
         );
@@ -54,7 +54,7 @@ class SecurityListenerTest extends BaseTest
     public function testOnKernelRequestSubRequestFragment()
     {
         $event = new GetResponseEvent(
-            $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock(HttpKernelInterface::class),
             Request::create('/_fragment'),
             HttpKernelInterface::MASTER_REQUEST
         );

--- a/bundle/Tests/SetupWizard/ConfigurationConverterTest.php
+++ b/bundle/Tests/SetupWizard/ConfigurationConverterTest.php
@@ -10,20 +10,24 @@
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\SetupWizard;
 
 use eZ\Publish\Core\MVC\Legacy\Tests\LegacyBasedTestCase;
+use eZ\Bundle\EzPublishLegacyBundle\SetupWizard\ConfigurationConverter;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\MVC\Legacy\Kernel;
+use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Configuration\LegacyConfigResolver;
 use Exception;
+use ezpKernelResult;
 
 class ConfigurationConverterTest extends LegacyBasedTestCase
 {
     protected function getConfigurationConverterMock(array $constructorParams)
     {
-        return $this->getMock(
-            'eZ\\Bundle\\EzPublishLegacyBundle\\SetupWizard\\ConfigurationConverter',
-            array(
+        return $this->getMockBuilder(ConfigurationConverter::class)
+            ->setConstructorArgs($constructorParams)
+            ->setMethods([
                 'getParameter',
                 'getGroup',
-            ),
-            $constructorParams
-        );
+            ])
+            ->getMock();
     }
 
     /**
@@ -179,7 +183,7 @@ class ConfigurationConverterTest extends LegacyBasedTestCase
             ),
         );
 
-        $exceptionType = 'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException';
+        $exceptionType = InvalidArgumentException::class;
 
         $commonMockParameters = array(
             'getParameter' => array(
@@ -399,7 +403,7 @@ class ConfigurationConverterTest extends LegacyBasedTestCase
     protected function getLegacyConfigResolverMock(array $methodsToMock = array())
     {
         $mock = $this
-            ->getMockBuilder('eZ\\Bundle\\EzPublishLegacyBundle\\DependencyInjection\\Configuration\\LegacyConfigResolver')
+            ->getMockBuilder(LegacyConfigResolver::class)
             ->setMethods(array_merge($methodsToMock, array('getParameter', 'getGroup')))
             ->disableOriginalConstructor()
             ->getMock();
@@ -413,7 +417,7 @@ class ConfigurationConverterTest extends LegacyBasedTestCase
     protected function getLegacyKernelMock()
     {
         $legacyKernelMock = $this
-            ->getMockBuilder('eZ\\Publish\\Core\\MVC\\Legacy\\Kernel')
+            ->getMockBuilder(Kernel::class)
             ->setMethods(array('runCallback'))
             ->disableOriginalConstructor()
             ->getMock();
@@ -421,7 +425,7 @@ class ConfigurationConverterTest extends LegacyBasedTestCase
         $legacyKernelMock
             ->expects($this->any())
             ->method('runCallback')
-            ->will($this->returnValue('ezpKernelResult'));
+            ->will($this->returnValue(ezpKernelResult::class));
 
         $closureMock = function () use ($legacyKernelMock) {
             return $legacyKernelMock;

--- a/bundle/Tests/SetupWizard/ConfigurationConverterTest.php
+++ b/bundle/Tests/SetupWizard/ConfigurationConverterTest.php
@@ -416,12 +416,7 @@ class ConfigurationConverterTest extends LegacyBasedTestCase
      */
     protected function getLegacyKernelMock()
     {
-        $legacyKernelMock = $this
-            ->getMockBuilder(Kernel::class)
-            ->setMethods(array('runCallback'))
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $legacyKernelMock = $this->createMock(Kernel::class);
         $legacyKernelMock
             ->expects($this->any())
             ->method('runCallback')

--- a/bundle/Tests/SetupWizard/ConfigurationDumperTest.php
+++ b/bundle/Tests/SetupWizard/ConfigurationDumperTest.php
@@ -12,9 +12,10 @@ namespace eZ\Bundle\EzPublishLegacyBundle\Tests\SetupWizard;
 use eZ\Bundle\EzPublishLegacyBundle\SetupWizard\ConfigurationDumper;
 use eZ\Publish\Core\MVC\Symfony\ConfigDumperInterface;
 use Symfony\Component\Yaml\Yaml;
-use PHPUnit_Framework_TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use PHPUnit\Framework\TestCase;
 
-class ConfigurationDumperTest extends PHPUnit_Framework_TestCase
+class ConfigurationDumperTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
@@ -33,7 +34,7 @@ class ConfigurationDumperTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->fs = $this->getMock('Symfony\\Component\\Filesystem\\Filesystem');
+        $this->fs = $this->createMock(Filesystem::class);
         $this->cacheDir = __DIR__ . '/cache';
         $this->configDir = __DIR__ . '/config';
         @mkdir($this->configDir);

--- a/bundle/Tests/SiteAccess/LegacyMapperTest.php
+++ b/bundle/Tests/SiteAccess/LegacyMapperTest.php
@@ -13,6 +13,9 @@ use eZ\Publish\Core\MVC\Legacy\Tests\LegacyBasedTestCase;
 use eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\SiteAccess as LegacyMapper;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Legacy\Event\PreBuildKernelWebHandlerEvent;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
 
 class LegacyMapperTest extends LegacyBasedTestCase
 {
@@ -53,7 +56,7 @@ class LegacyMapperTest extends LegacyBasedTestCase
 
         $mapper = new LegacyMapper();
         $mapper->setContainer($container);
-        $bag = new \Symfony\Component\HttpFoundation\ParameterBag();
+        $bag = new ParameterBag();
         $mapper->onBuildKernelWebHandler(
             new PreBuildKernelWebHandlerEvent(
                 $bag,
@@ -337,7 +340,7 @@ class LegacyMapperTest extends LegacyBasedTestCase
     private function getRequestMock(array $methodsToMock = array())
     {
         return $this
-            ->getMockBuilder('Symfony\\Component\\HttpFoundation\\Request')
+            ->getMockBuilder(Request::class)
             ->setMethods(array_merge(array('getPathInfo'), $methodsToMock))
             ->getMock();
     }
@@ -350,7 +353,7 @@ class LegacyMapperTest extends LegacyBasedTestCase
     private function getContainerMock(array $methodsToMock = array())
     {
         return $this
-            ->getMockBuilder('Symfony\\Component\\DependencyInjection\\ContainerInterface')
+            ->getMockBuilder(ContainerInterface::class)
             ->setMethods($methodsToMock)
             ->getMock();
     }

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "phpunit/phpunit": "^5.7",
-        "mikey179/vfsStream": "~1.1.0",
-        "mockery/mockery": "^0.9"
+        "mikey179/vfsStream": "~1.1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
-        "phpunit/phpunit": "~4.7",
+        "phpunit/phpunit": "^5.7",
         "mikey179/vfsStream": "~1.1.0",
         "mockery/mockery": "^0.9"
     },

--- a/mvc/Templating/Tests/Adapter/DefinitionBasedAdapterTest.php
+++ b/mvc/Templating/Tests/Adapter/DefinitionBasedAdapterTest.php
@@ -10,13 +10,14 @@
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests\Adapter;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\MVC\Legacy\Templating\Adapter\DefinitionBasedAdapter;
 
 class DefinitionBasedAdapterTest extends ValueObjectAdapterTest
 {
     protected function getAdapter(ValueObject $valueObject, array $map)
     {
         $adapter = $this
-            ->getMockBuilder('eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\Adapter\\DefinitionBasedAdapter')
+            ->getMockBuilder(DefinitionBasedAdapter::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $adapter

--- a/mvc/Templating/Tests/Adapter/ValueObjectAdapterTest.php
+++ b/mvc/Templating/Tests/Adapter/ValueObjectAdapterTest.php
@@ -10,10 +10,11 @@
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests\Adapter;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\Adapter\ValueObjectAdapter;
+use eZ\Publish\Core\FieldType\Page\Parts\Zone;
 use eZ\Publish\API\Repository\Values\ValueObject;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ValueObjectAdapterTest extends PHPUnit_Framework_TestCase
+class ValueObjectAdapterTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
@@ -55,7 +56,7 @@ class ValueObjectAdapterTest extends PHPUnit_Framework_TestCase
             },
         );
         $this->valueObject = $this
-            ->getMockBuilder('eZ\\Publish\\Core\\FieldType\\Page\\Parts\\Zone')
+            ->getMockBuilder(Zone::class)
             ->setConstructorArgs(
                 array(
                     $this->validProperties,

--- a/mvc/Templating/Tests/Converter/PagePartsConverterTest.php
+++ b/mvc/Templating/Tests/Converter/PagePartsConverterTest.php
@@ -11,9 +11,13 @@ namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests\Converter;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\Converter\PagePartsConverter;
 use eZ\Publish\API\Repository\Values\ValueObject;
-use PHPUnit_Framework_TestCase;
+use eZ\Publish\Core\MVC\Legacy\Templating\Adapter\BlockAdapter;
+use eZ\Publish\Core\FieldType\Page\Parts\Block;
+use eZ\Publish\Core\FieldType\Page\Parts\Zone;
+use eZ\Publish\Core\MVC\Legacy\Templating\Adapter\ZoneAdapter;
+use PHPUnit\Framework\TestCase;
 
-class PagePartsConverterTest extends PHPUnit_Framework_TestCase
+class PagePartsConverterTest extends TestCase
 {
     /**
      * @dataProvider convertProvider
@@ -33,17 +37,17 @@ class PagePartsConverterTest extends PHPUnit_Framework_TestCase
         return array(
             array(
                 $this
-                    ->getMockBuilder('eZ\\Publish\\Core\\FieldType\\Page\\Parts\\Block')
+                    ->getMockBuilder(Block::class)
                     ->disableOriginalConstructor()
                     ->getMock(),
-                'eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\Adapter\\BlockAdapter',
+                BlockAdapter::class,
             ),
             array(
                 $this
-                    ->getMockBuilder('eZ\\Publish\\Core\\FieldType\\Page\\Parts\\Zone')
+                    ->getMockBuilder(Zone::class)
                     ->disableOriginalConstructor()
                     ->getMock(),
-                'eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\Adapter\\ZoneAdapter',
+                ZoneAdapter::class,
             ),
         );
     }
@@ -77,6 +81,6 @@ class PagePartsConverterTest extends PHPUnit_Framework_TestCase
     public function testConvertFailWrongType()
     {
         $converter = new PagePartsConverter();
-        $converter->convert($this->getMock('eZ\\Publish\\API\\Repository\\Values\\ValueObject'));
+        $converter->convert($this->createMock(ValueObject::class));
     }
 }

--- a/mvc/Templating/Tests/Converter/PagePartsConverterTest.php
+++ b/mvc/Templating/Tests/Converter/PagePartsConverterTest.php
@@ -36,17 +36,11 @@ class PagePartsConverterTest extends TestCase
     {
         return array(
             array(
-                $this
-                    ->getMockBuilder(Block::class)
-                    ->disableOriginalConstructor()
-                    ->getMock(),
+                $this->createMock(Block::class),
                 BlockAdapter::class,
             ),
             array(
-                $this
-                    ->getMockBuilder(Zone::class)
-                    ->disableOriginalConstructor()
-                    ->getMock(),
+                $this->createMock(Zone::class),
                 ZoneAdapter::class,
             ),
         );

--- a/mvc/Templating/Tests/GlobalHelperTest.php
+++ b/mvc/Templating/Tests/GlobalHelperTest.php
@@ -25,8 +25,7 @@ class GlobalHelperTest extends BaseGlobalHelperTest
         parent::setUp();
         $this->legacyHelper = $this->getMockBuilder(LegacyHelper::class)
             ->setConstructorArgs([
-                function() {
-
+                function () {
                 },
             ])
             ->setMethods([])

--- a/mvc/Templating/Tests/GlobalHelperTest.php
+++ b/mvc/Templating/Tests/GlobalHelperTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\GlobalHelper;
 use eZ\Publish\Core\MVC\Symfony\Templating\Tests\GlobalHelperTest as BaseGlobalHelperTest;
+use eZ\Publish\Core\MVC\Legacy\Templating\LegacyHelper;
 
 class GlobalHelperTest extends BaseGlobalHelperTest
 {
@@ -22,14 +23,15 @@ class GlobalHelperTest extends BaseGlobalHelperTest
     protected function setUp()
     {
         parent::setUp();
-        $this->legacyHelper = $this->getMock(
-            'eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\LegacyHelper',
-            array(),
-            array(
-                function () {
+        $this->legacyHelper = $this->getMockBuilder(LegacyHelper::class)
+            ->setConstructorArgs([
+                function() {
+
                 },
-            )
-        );
+            ])
+            ->setMethods([])
+            ->getMock();
+
         // Force to use Legacy GlobalHelper
         $this->helper = new GlobalHelper($this->configResolver, $this->locationService, $this->router, $this->translationHelper);
         $this->helper->setLegacyHelper($this->legacyHelper);

--- a/mvc/Templating/Tests/LegacyEngineTest.php
+++ b/mvc/Templating/Tests/LegacyEngineTest.php
@@ -10,9 +10,10 @@
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine;
-use PHPUnit_Framework_TestCase;
+use eZ\Publish\Core\MVC\Legacy\Templating\Converter\MultipleObjectConverter;
+use PHPUnit\Framework\TestCase;
 
-class LegacyEngineTest extends PHPUnit_Framework_TestCase
+class LegacyEngineTest extends TestCase
 {
     /**
      * @var \eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine
@@ -25,7 +26,7 @@ class LegacyEngineTest extends PHPUnit_Framework_TestCase
         $this->engine = new LegacyEngine(
             function () {
             },
-            $this->getMock('eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\Converter\\MultipleObjectConverter')
+            $this->createMock(MultipleObjectConverter::class)
         );
     }
 

--- a/mvc/Templating/Tests/Twig/EnvironmentTest.php
+++ b/mvc/Templating/Tests/Twig/EnvironmentTest.php
@@ -23,9 +23,7 @@ class EnvironmentTest extends TestCase
      */
     public function testLoadTemplateLegacy()
     {
-        $legacyEngine = $this->getMockBuilder(LegacyEngine::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $legacyEngine = $this->createMock(LegacyEngine::class);
 
         $templateName = 'design:test/helloworld.tpl';
         $legacyEngine->expects($this->any())
@@ -56,9 +54,7 @@ class EnvironmentTest extends TestCase
      */
     public function testLoadNonExistingTemplateLegacy()
     {
-        $legacyEngine = $this->getMockBuilder(LegacyEngine::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $legacyEngine = $this->createMock(LegacyEngine::class);
 
         $templateName = 'design:test/helloworld.tpl';
         $legacyEngine->expects($this->any())

--- a/mvc/Templating/Tests/Twig/EnvironmentTest.php
+++ b/mvc/Templating/Tests/Twig/EnvironmentTest.php
@@ -10,9 +10,12 @@
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests\Twig;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\Twig\Environment;
-use PHPUnit_Framework_TestCase;
+use eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine;
+use eZ\Publish\Core\MVC\Legacy\Templating\Twig\Template;
+use PHPUnit\Framework\TestCase;
+use Twig_LoaderInterface;
 
-class EnvironmentTest extends PHPUnit_Framework_TestCase
+class EnvironmentTest extends TestCase
 {
     /**
      * @covers \eZ\Publish\Core\MVC\Legacy\Templating\Twig\Environment::loadTemplate
@@ -20,7 +23,7 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
      */
     public function testLoadTemplateLegacy()
     {
-        $legacyEngine = $this->getMockBuilder('eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\LegacyEngine')
+        $legacyEngine = $this->getMockBuilder(LegacyEngine::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -35,10 +38,10 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
             ->with($templateName)
             ->will($this->returnValue(true));
 
-        $twigEnv = new Environment($this->getMock('Twig_LoaderInterface'));
+        $twigEnv = new Environment($this->createMock(Twig_LoaderInterface::class));
         $twigEnv->setEzLegacyEngine($legacyEngine);
         $template = $twigEnv->loadTemplate($templateName);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\Twig\\Template', $template);
+        $this->assertInstanceOf(Template::class, $template);
         $this->assertSame($templateName, $template->getTemplateName());
 
         // Calling loadTemplate a 2nd time with the same template name should return the very same Template object.
@@ -53,7 +56,7 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
      */
     public function testLoadNonExistingTemplateLegacy()
     {
-        $legacyEngine = $this->getMockBuilder('eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\LegacyEngine')
+        $legacyEngine = $this->getMockBuilder(LegacyEngine::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -68,8 +71,8 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
             ->with($templateName)
             ->will($this->returnValue(false));
 
-        $twigEnv = new Environment($this->getMock('Twig_LoaderInterface'));
+        $twigEnv = new Environment($this->createMock(Twig_LoaderInterface::class));
         $twigEnv->setEzLegacyEngine($legacyEngine);
-        $template = $twigEnv->loadTemplate($templateName);
+        $twigEnv->loadTemplate($templateName);
     }
 }

--- a/mvc/Templating/Tests/Twig/LoaderStringTest.php
+++ b/mvc/Templating/Tests/Twig/LoaderStringTest.php
@@ -10,10 +10,10 @@
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests\Twig;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\Twig\LoaderString;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Twig_Source;
 
-class LoaderStringTest extends PHPUnit_Framework_TestCase
+class LoaderStringTest extends TestCase
 {
     public function testGetSource()
     {

--- a/mvc/Templating/Tests/Twig/TemplateTest.php
+++ b/mvc/Templating/Tests/Twig/TemplateTest.php
@@ -36,14 +36,8 @@ class TemplateTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->legacyEngine = $this->getMockBuilder(LegacyEngine::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->twigEnv = $this->getMockBuilder(Environment::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $this->legacyEngine = $this->createMock(LegacyEngine::class);
+        $this->twigEnv = $this->createMock(Environment::class);
         $this->template = new Template(self::TEMPLATE_NAME, $this->twigEnv, $this->legacyEngine);
     }
 

--- a/mvc/Templating/Tests/Twig/TemplateTest.php
+++ b/mvc/Templating/Tests/Twig/TemplateTest.php
@@ -10,9 +10,11 @@
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests\Twig;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\Twig\Template;
-use PHPUnit_Framework_TestCase;
+use eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine;
+use eZ\Publish\Core\MVC\Legacy\Templating\Twig\Environment;
+use PHPUnit\Framework\TestCase;
 
-class TemplateTest extends PHPUnit_Framework_TestCase
+class TemplateTest extends TestCase
 {
     const TEMPLATE_NAME = 'design:hello_world.tpl';
 
@@ -34,11 +36,11 @@ class TemplateTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->legacyEngine = $this->getMockBuilder('eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\LegacyEngine')
+        $this->legacyEngine = $this->getMockBuilder(LegacyEngine::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->twigEnv = $this->getMockBuilder('eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\Twig\\Environment')
+        $this->twigEnv = $this->getMockBuilder(Environment::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/mvc/Tests/Event/PostBuildKernelEventTest.php
+++ b/mvc/Tests/Event/PostBuildKernelEventTest.php
@@ -10,15 +10,17 @@
 namespace eZ\Publish\Core\MVC\Legacy\Tests\Event;
 
 use eZ\Publish\Core\MVC\Legacy\Event\PostBuildKernelEvent;
-use PHPUnit_Framework_TestCase;
+use eZ\Publish\Core\MVC\Legacy\Kernel;
+use PHPUnit\Framework\TestCase;
+use ezpKernelHandler;
 
-class PostBuildKernelEventTest extends PHPUnit_Framework_TestCase
+class PostBuildKernelEventTest extends TestCase
 {
     public function testConstruct()
     {
-        $kernelHandler = $this->getMock('ezpKernelHandler');
+        $kernelHandler = $this->createMock(ezpKernelHandler::class);
         $legacyKernel = $this
-            ->getMockBuilder('eZ\Publish\Core\MVC\Legacy\Kernel')
+            ->getMockBuilder(Kernel::class)
             ->setConstructorArgs(array($kernelHandler, 'foo', 'bar'))
             ->getMock();
         $event = new PostBuildKernelEvent($legacyKernel, $kernelHandler);

--- a/mvc/Tests/Event/PreBuildKernelEventTest.php
+++ b/mvc/Tests/Event/PreBuildKernelEventTest.php
@@ -10,10 +10,10 @@
 namespace eZ\Publish\Core\MVC\Legacy\Tests\Event;
 
 use eZ\Publish\Core\MVC\Legacy\Event\PreBuildKernelEvent;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
-class PreBuildKernelEventTest extends PHPUnit_Framework_TestCase
+class PreBuildKernelEventTest extends TestCase
 {
     public function testConstruct()
     {

--- a/mvc/Tests/Event/PreBuildKernelWebHandlerEventTest.php
+++ b/mvc/Tests/Event/PreBuildKernelWebHandlerEventTest.php
@@ -10,11 +10,11 @@
 namespace eZ\Publish\Core\MVC\Legacy\Tests\Event;
 
 use eZ\Publish\Core\MVC\Legacy\Event\PreBuildKernelWebHandlerEvent;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 
-class PreBuildKernelWebHandlerEventTest extends PHPUnit_Framework_TestCase
+class PreBuildKernelWebHandlerEventTest extends TestCase
 {
     public function testConstruct()
     {

--- a/mvc/Tests/Image/AliasCleanerTest.php
+++ b/mvc/Tests/Image/AliasCleanerTest.php
@@ -10,9 +10,11 @@
 namespace eZ\Publish\Core\MVC\Legacy\Tests\Image;
 
 use eZ\Publish\Core\MVC\Legacy\Image\AliasCleaner;
-use PHPUnit_Framework_TestCase;
+use eZ\Publish\Core\FieldType\Image\AliasCleanerInterface;
+use eZ\Publish\Core\IO\UrlRedecoratorInterface;
+use PHPUnit\Framework\TestCase;
 
-class AliasCleanerTest extends PHPUnit_Framework_TestCase
+class AliasCleanerTest extends TestCase
 {
     /**
      * @var \eZ\Publish\Core\MVC\Legacy\Image\AliasCleaner
@@ -32,8 +34,8 @@ class AliasCleanerTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->innerAliasCleaner = $this->getMock('eZ\Publish\Core\FieldType\Image\AliasCleanerInterface');
-        $this->urlRedecorator = $this->getMock('eZ\Publish\Core\IO\UrlRedecoratorInterface');
+        $this->innerAliasCleaner = $this->createMock(AliasCleanerInterface::class);
+        $this->urlRedecorator = $this->createMock(UrlRedecoratorInterface::class);
         $this->aliasCleaner = new AliasCleaner($this->innerAliasCleaner, $this->urlRedecorator);
     }
 

--- a/mvc/Tests/KernelTest.php
+++ b/mvc/Tests/KernelTest.php
@@ -13,10 +13,10 @@ use Exception;
 use eZ\Publish\Core\MVC\Legacy\Kernel;
 use ezpKernelHandler;
 use PHPUnit_Framework_MockObject_MockObject;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-class KernelTest extends PHPUnit_Framework_TestCase
+class KernelTest extends TestCase
 {
     /** @var ezpKernelHandler|PHPUnit_Framework_MockObject_MockObject */
     protected $kernelHandlerMock;
@@ -62,7 +62,7 @@ class KernelTest extends PHPUnit_Framework_TestCase
     protected function getKernelHandlerMock()
     {
         if (!isset($this->kernelHandlerMock)) {
-            $this->kernelHandlerMock = $this->getMock('ezpKernelHandler');
+            $this->kernelHandlerMock = $this->createMock(ezpKernelHandler::class);
         }
 
         return $this->kernelHandlerMock;

--- a/mvc/Tests/LegacyBasedTestCase.php
+++ b/mvc/Tests/LegacyBasedTestCase.php
@@ -9,12 +9,12 @@
 
 namespace eZ\Publish\Core\MVC\Legacy\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Base test case for legacy based tests.
  */
-abstract class LegacyBasedTestCase extends PHPUnit_Framework_TestCase
+abstract class LegacyBasedTestCase extends TestCase
 {
     protected function setUp()
     {

--- a/mvc/Tests/Security/SSOListenerTest.php
+++ b/mvc/Tests/Security/SSOListenerTest.php
@@ -9,18 +9,23 @@
 
 namespace eZ\Publish\Core\MVC\Legacy\Tests\Security;
 
+use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\Core\MVC\Legacy\Security\Firewall\SSOListener;
 use eZ\Publish\Core\MVC\Symfony\Security\User;
 use eZ\Publish\Core\Repository\Values\User\User as CoreUser;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use eZUser;
+use ezpKernelHandler;
+use Closure;
 
-class SSOListenerTest extends PHPUnit_Framework_TestCase
+class SSOListenerTest extends TestCase
 {
     /**
      * @var \eZ\Publish\Core\MVC\Legacy\Security\Firewall\SSOListener
@@ -47,17 +52,17 @@ class SSOListenerTest extends PHPUnit_Framework_TestCase
         parent::setUp();
 
         $this->ssoListener = new SSOListener(
-            $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'),
-            $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface'),
+            $this->createMock(TokenStorageInterface::class),
+            $this->createMock(AuthenticationManagerInterface::class),
             'firewall_key'
         );
 
-        $legacyKernel = $this->legacyKernel = $this->getMock('ezpKernelHandler');
+        $legacyKernel = $this->legacyKernel = $this->createMock(ezpKernelHandler::class);
         $this->legacyKernelClosure = function () use ($legacyKernel) {
             return $legacyKernel;
         };
 
-        $this->userService = $this->getMock('eZ\Publish\API\Repository\UserService');
+        $this->userService = $this->createMock(UserService::class);
     }
 
     public function testGetPreAuthenticatedDataNoUser()
@@ -72,7 +77,7 @@ class SSOListenerTest extends PHPUnit_Framework_TestCase
         $this->legacyKernel
             ->expects($this->once())
             ->method('runCallback')
-            ->with($this->isInstanceOf('\Closure'), false)
+            ->with($this->isInstanceOf(Closure::class), false)
             ->will($this->returnValue(null));
 
         $refListener = new ReflectionObject($this->ssoListener);

--- a/mvc/Tests/SignalSlot/LegacySlotsTest.php
+++ b/mvc/Tests/SignalSlot/LegacySlotsTest.php
@@ -10,12 +10,15 @@
 namespace eZ\Publish\Core\MVC\Legacy\Tests\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot;
-use PHPUnit_Framework_TestCase;
+use eZ\Publish\Core\MVC\Legacy\SignalSlot\AbstractLegacySlot;
+use eZ\Bundle\EzPublishLegacyBundle\Cache\Switchable;
+use PHPUnit\Framework\TestCase;
+use ezpKernelHandler;
 
 /**
  * @group signalSlot
  */
-class LegacySlotsTest extends PHPUnit_Framework_TestCase
+class LegacySlotsTest extends TestCase
 {
     const SIGNAL_SLOT_NS = 'eZ\Publish\Core\SignalSlot';
     const LEGACY_SIGNAL_SLOT_NS = 'eZ\Publish\Core\MVC\Legacy\SignalSlot';
@@ -33,10 +36,10 @@ class LegacySlotsTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->ezpKernelHandlerMock = $this->getMock('\ezpKernelHandler');
+        $this->ezpKernelHandlerMock = $this->createMock(ezpKernelHandler::class);
 
-        $this->persistenceCachePurgerMock = $this->getMockForTrait('eZ\Bundle\EzPublishLegacyBundle\Cache\Switchable');
-        $this->httpCachePurgerMock = $this->getMockForTrait('eZ\Bundle\EzPublishLegacyBundle\Cache\Switchable');
+        $this->persistenceCachePurgerMock = $this->getMockForTrait(Switchable::class);
+        $this->httpCachePurgerMock = $this->getMockForTrait(Switchable::class);
 
         parent::setUp();
     }
@@ -48,19 +51,16 @@ class LegacySlotsTest extends PHPUnit_Framework_TestCase
     {
         $ezpKernelHandlerMock = $this->ezpKernelHandlerMock;
 
-        $legacySlotMock = $this->getMock(
-            'eZ\Publish\Core\MVC\Legacy\SignalSlot\AbstractLegacySlot',
-            // methods
-            array(),
-            // ctor arguments
-            array(
+        $legacySlotMock = $this->getMockBuilder(AbstractLegacySlot::class)
+            ->setConstructorArgs([
                 $ezpKernelHandlerMock,
                 $this->persistenceCachePurgerMock,
                 $this->httpCachePurgerMock,
-            )
-        );
+            ])
+            ->setMethods([])
+            ->getMock();
 
-        $reflectionProperty = new \ReflectionProperty('eZ\Publish\Core\MVC\Legacy\SignalSlot\AbstractLegacySlot', 'legacyKernel');
+        $reflectionProperty = new \ReflectionProperty(AbstractLegacySlot::class, 'legacyKernel');
         $reflectionProperty->setAccessible(true);
 
         $this->assertSame($ezpKernelHandlerMock, $reflectionProperty->getValue($legacySlotMock));
@@ -145,7 +145,7 @@ class LegacySlotsTest extends PHPUnit_Framework_TestCase
         /**
          * @var \eZ\Publish\Core\SignalSlot\Signal
          */
-        $signal = $this->getMock(self::SIGNAL_SLOT_NS . '\\Signal');
+        $signal = $this->createMock(self::SIGNAL_SLOT_NS . '\\Signal');
         $slot->receive($signal);
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,7 +5,7 @@
   convertErrorsToExceptions="true"
   convertNoticesToExceptions="true"
   convertWarningsToExceptions="true"
-  colors="false"
+  colors="true"
   >
   <testsuites>
     <testsuite name="eZ Publish Legacy MVC suite">


### PR DESCRIPTION
This PR resolves:
* tests now extend namespaced `TestCase`
* removed deprecated `getMock` method calls
* removed deprecated `setExpectedException` method calls
* removed Mockery library (we do not need it, just two stubs were created by it) -> replaced with PHPUnit syntax

Notice:
There are still some warning messages popping up, but those are coming from `ezpublish-kernel` .