### PR TITLE
Add missing siteaccess option definition to LegacyEmbedScriptCommand

### DIFF
--- a/bundle/Command/LegacyEmbedScriptCommand.php
+++ b/bundle/Command/LegacyEmbedScriptCommand.php
@@ -28,6 +28,7 @@ class LegacyEmbedScriptCommand extends ContainerAwareCommand
             ->setName('ezpublish:legacy:script')
             ->addArgument('script', InputArgument::REQUIRED, 'Path to legacy script you want to run. Path must be relative to the legacy root')
             ->addOption('legacy-help', null, InputOption::VALUE_NONE, 'Use this option if you want to display help for the legacy script')
+            ->addOption('siteaccess', null, InputOption::VALUE_NONE, 'Use this option if you want to set the siteaccess for the legacy script')
             ->setDescription('Runs an eZ Publish legacy script.')
             ->setHelp(
                 <<<EOT


### PR DESCRIPTION
In line 63 the option is used but is not defined.

If you want use it, an error occurs.