### PR TITLE
Add missing argument to ezpublish.http_cache.purger.instant

### DIFF
--- a/bundle/DependencyInjection/Compiler/HttpCachePass.php
+++ b/bundle/DependencyInjection/Compiler/HttpCachePass.php
@@ -31,6 +31,7 @@ class HttpCachePass implements CompilerPassInterface
                     new Reference('ezplatform.http_cache.purge_client'),
                     new Reference('ezpublish.api.service.inner_content'),
                     new Reference('ezpublish.http_cache.event_dispatcher'),
+                    new Reference('ezpublish.api.repository'),
                 ]
             ),
         ]);


### PR DESCRIPTION
For support for 6.7.7, 6.12.1 and 6.13.0

Still there is no way to properly solve this since at this point any reference to old `ezpublish.http_cache.purger.instant` is removed from the container and we simply do not know the list of arguments.