### PR TITLE
Always return location IDs from SwitchableHttpCachePurger::purge

### DIFF
--- a/bundle/Cache/SwitchableHttpCachePurger.php
+++ b/bundle/Cache/SwitchableHttpCachePurger.php
@@ -30,7 +30,9 @@ class SwitchableHttpCachePurger implements GatewayCachePurger
             return $locationIds;
         }
 
-        return $this->gatewayCachePurger->purge($locationIds);
+        $this->gatewayCachePurger->purge($locationIds);
+
+        return $locationIds;
     }
 
     public function purgeAll()


### PR DESCRIPTION
This fixes clearing view caches in legacy admin interface running in `legacy_mode: false`, e.g. Netgen Admin UI.

eZ Publish Legacy expects that `content/cache` events always return location
IDs they were given (https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/classes/ezcontentcachemanager.php#L772).

In eZ Publish kernel 6.x, there was an InstantCachePurger that did this
(https://github.com/ezsystems/ezpublish-kernel/blob/6.13/eZ/Publish/Core/MVC/Symfony/Cache/Http/InstantCachePurger.php#L61-L66),
but in 7.0 (and presumably with 6.x with new HttpCacheBundle turned on),
this does not happen.

So here, we make sure that location IDs are always returned, no matter what.