### PR TITLE
[Feature] Set legacy in DevMode & DebugOuput when symfony is in debug

### DIFF
--- a/bundle/LegacyMapper/Configuration.php
+++ b/bundle/LegacyMapper/Configuration.php
@@ -180,7 +180,7 @@ class Configuration implements EventSubscriberInterface
         // Cache settings
         // Enforce ViewCaching to be enabled in order to persistence/http cache to be purged correctly.
         $settings['site.ini/ContentSettings/ViewCaching'] = 'enabled';
-        
+
         // Dev / Debug
         // if symfony is in debug mode, also put legacy in dev mode as a convention for ease of use
         if ($this->container->getParameter('kernel.debug')) {

--- a/bundle/LegacyMapper/Configuration.php
+++ b/bundle/LegacyMapper/Configuration.php
@@ -180,6 +180,13 @@ class Configuration implements EventSubscriberInterface
         // Cache settings
         // Enforce ViewCaching to be enabled in order to persistence/http cache to be purged correctly.
         $settings['site.ini/ContentSettings/ViewCaching'] = 'enabled';
+        
+        // Dev / Debug
+        // if symfony is in debug mode, also put legacy in dev mode as a convention for ease of use
+        if ($this->container->getParameter('kernel.debug')) {
+            $settings['site.ini/DebugSettings/DebugOutput'] = 'enabled';
+            $settings['site.ini/TemplateSettings/DevelopmentMode'] = 'enabled';
+        }
 
         $event->getParameters()->set(
             'injected-settings',


### PR DESCRIPTION
Could have checked for kernel.env === dev also in some form, but seems seemed cleaner, up for debate if we want this tough.