### PR TITLE
EZP-28736: SPI cache not cleared when a content is published via a delayed publication workflow

### DIFF
--- a/bundle/Cache/PersistenceCachePurger.php
+++ b/bundle/Cache/PersistenceCachePurger.php
@@ -101,13 +101,13 @@ class PersistenceCachePurger implements CacheClearerInterface
      * Either way all location and urlAlias cache is cleared as well.
      *
      * @param int|int[]|null $locationIds Ids of location we need to purge content cache for. Purges all content cache if null
-     * @param int|int[]|null $contentIds Ids of content we need to purge
+     * @param int[]|null $contentIds Ids of content we need to purge
      *
      * @return array|int|\int[]|null
      *
      * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType On invalid $id type
      */
-    public function content($locationIds = null, $contentIds = null)
+    public function content($locationIds = null, array $contentIds = null)
     {
         if ($this->allCleared === true || $this->isSwitchedOff()) {
             return $locationIds;
@@ -122,8 +122,6 @@ class PersistenceCachePurger implements CacheClearerInterface
 
         if ($contentIds === null) {
             $contentIds = array();
-        } elseif (!is_array($contentIds)) {
-            $contentIds = array($contentIds);
         }
 
         foreach ($locationIds as $id) {
@@ -139,6 +137,7 @@ class PersistenceCachePurger implements CacheClearerInterface
                 );
             }
         }
+
         foreach (array_unique($contentIds) as $id) {
             if (!is_scalar($id)) {
                 throw new InvalidArgumentType('$id', 'int[]|null', $id);

--- a/bundle/Cache/PersistenceCachePurger.php
+++ b/bundle/Cache/PersistenceCachePurger.php
@@ -139,14 +139,13 @@ class PersistenceCachePurger implements CacheClearerInterface
                 );
             }
         }
-        foreach ($contentIds as $id) {
+        foreach (array_unique($contentIds) as $id) {
             if (!is_scalar($id)) {
                 throw new InvalidArgumentType('$id', 'int[]|null', $id);
             }
 
             $this->cache->clear('content', $id);
             $this->cache->clear('content', 'info', $id);
-            $this->cache->clear('content', 'info', 'remoteId');
             $this->cache->clear('content', 'locations', $id);
             $this->cache->clear('user', 'role', 'assignments', 'byGroup', $id);
             $this->cache->clear('user', 'role', 'assignments', 'byGroup', 'inherited', $id);
@@ -154,6 +153,7 @@ class PersistenceCachePurger implements CacheClearerInterface
 
         // clear content related cache as well
         relatedCache:
+        $this->cache->clear('content', 'info', 'remoteId');
         $this->cache->clear('urlAlias');
         $this->cache->clear('location');
 


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28736

## Description

This PR adds the second optional argument to `\eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::content` for affected objectIds, and use it for clearing the relevant content cache. This allows us to avoid of location loading in cache purging, which may cause issues when cache purging is executed in the in the middle of a transaction started by the legacy database connection.   

Changes suggested in https://github.com/ezsystems/ezpublish-legacy/pull/1343#issuecomment-357519202

- [x] Adjust the `ezcontentcachemanager::clearNodeViewCacheArray` / `eZContentOperationCollection::removeNodes` calls in ezpublish-legacy (https://github.com/ezsystems/ezpublish-legacy/pull/1345)