### PR TITLE
EZP-28926: Add a legacy security voter decorator

### DIFF
--- a/bundle/Resources/config/security.yml
+++ b/bundle/Resources/config/security.yml
@@ -1,4 +1,20 @@
 services:
+    ezpublish_legacy.security.voter.core:
+        class: eZ\Publish\Core\MVC\Legacy\Security\Voter\VoterDecorator
+        decorates: ezpublish.security.voter.core
+        public: false
+        arguments: ["@ezpublish_legacy.security.voter.core.inner", "@ezpublish_legacy.kernel"]
+        tags:
+            - { name: security.voter }
+
+    ezpublish_legacy.security.voter.value_object:
+        class: eZ\Publish\Core\MVC\Legacy\Security\Voter\VoterDecorator
+        decorates: ezpublish.security.voter.value_object
+        public: false
+        arguments: ["@ezpublish_legacy.security.voter.value_object.inner", "@ezpublish_legacy.kernel"]
+        tags:
+            - { name: security.voter }
+
     ezpublish_legacy.security.login_cleanup_listener:
         class: eZ\Publish\Core\MVC\Legacy\Security\Firewall\LoginCleanupListener
         public: false

--- a/bundle/Resources/config/security.yml
+++ b/bundle/Resources/config/security.yml
@@ -4,16 +4,12 @@ services:
         decorates: ezpublish.security.voter.core
         public: false
         arguments: ["@ezpublish_legacy.security.voter.core.inner", "@ezpublish_legacy.kernel"]
-        tags:
-            - { name: security.voter }
 
     ezpublish_legacy.security.voter.value_object:
         class: eZ\Publish\Core\MVC\Legacy\Security\Voter\VoterDecorator
         decorates: ezpublish.security.voter.value_object
         public: false
         arguments: ["@ezpublish_legacy.security.voter.value_object.inner", "@ezpublish_legacy.kernel"]
-        tags:
-            - { name: security.voter }
 
     ezpublish_legacy.security.login_cleanup_listener:
         class: eZ\Publish\Core\MVC\Legacy\Security\Firewall\LoginCleanupListener

--- a/mvc/Security/Voter/VoterDecorator.php
+++ b/mvc/Security/Voter/VoterDecorator.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * This file is part of the eZ LegacyBridge package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\MVC\Legacy\Security\Voter;
+
+use Closure;
+use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
+use eZUser;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
+
+class VoterDecorator implements VoterInterface
+{
+    private $innerVoter;
+
+    private $legacyKernelClosure;
+
+    public function __construct(
+        VoterInterface $innerVoter,
+        Closure $legacyKernelClosure
+    ) {
+        $this->innerVoter = $innerVoter;
+        $this->legacyKernelClosure = $legacyKernelClosure;
+    }
+
+    public function supportsAttribute($attribute)
+    {
+        return $attribute instanceof AuthorizationAttribute;
+    }
+
+    public function supportsClass($class)
+    {
+        return true;
+    }
+
+    public function vote(TokenInterface $token, $object, array $attributes)
+    {
+        try {
+            return $this->innerVoter->vote($token, $object, $attributes);
+        } catch (InvalidArgumentException $e) {
+            $legacyResult = $this->voteLegacy($token, $object, $attributes);
+            if ($legacyResult === static::ACCESS_ABSTAIN) {
+                throw $e;
+            }
+
+            return $legacyResult;
+        }
+    }
+
+    private function voteLegacy(TokenInterface $token, $object, array $attributes)
+    {
+        $legacyKernel = call_user_func($this->legacyKernelClosure);
+        foreach ($attributes as $attribute) {
+            if (!$this->supportsAttribute($attribute)) {
+                continue;
+            }
+
+            $result = $legacyKernel->runCallback(
+                function () use ($attribute) {
+                    $currentUser = eZUser::currentUser();
+
+                    return $currentUser->hasAccessTo($attribute->module, $attribute->function);
+                },
+                false
+            );
+
+            if ($result['accessWord'] === 'no') {
+                return static::ACCESS_DENIED;
+            }
+
+            return static::ACCESS_GRANTED;
+        }
+
+        return static::ACCESS_ABSTAIN;
+    }
+}

--- a/mvc/Security/Voter/VoterDecorator.php
+++ b/mvc/Security/Voter/VoterDecorator.php
@@ -39,6 +39,16 @@ class VoterDecorator implements VoterInterface
         return true;
     }
 
+    /**
+     * Decorates the built in eZ kernel voters to allow eZ Publish legacy
+     * to vote on modules/functions available only in legacy kernel.
+     *
+     * @param \Symfony\Component\Security\Core\Authentication\Token\TokenInterface $token
+     * @param mixed $object
+     * @param array $attributes
+     *
+     * @return int
+     */
     public function vote(TokenInterface $token, $object, array $attributes)
     {
         try {


### PR DESCRIPTION
This allows checking for legacy modules/functions before exceptions are thrown.

It only rethrows the exception if for some reason this voter votes with `ACCESS_ABSTAIN`.

Needed for legacy permission checking after https://github.com/ezsystems/ezpublish-kernel/pull/2273.