### PR TITLE
[FEATURE]  Add command "init" to configure platform install for legacy bridge usage

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,76 +3,40 @@
 Instructions below will take you true installing legacy bridge and implicit legacy on top of a eZ Platform 1.13.x - 2.x
 install.
 
-### Add the composer `legacy post-*-scripts`
+_TIP:_
+> Before starting make sure to check-in (e.g. to Git) your eZ Platform project working space so you'll be able to see & verify changes applied to your setup separate from initial clean project install.
 
-Edit `composer.json`, and add those lines to both `post-update-cmd` and `post-install-cmd` blocks at the end, but before
-`eZ\Bundle\EzPublishCoreBundle\Composer\ScriptHandler::dumpAssets`:
+### Install `ezsystems/legacy-bridge` and run `init` command
+
+1. Installed package using [Composer](https://getcomposer.org/doc/00-intro.md):
 ```
-"scripts": {
-    "legacy-scripts": [
-        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installAssets",
-        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installLegacyBundlesExtensions",
-        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::generateAutoloads",
-        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::symlinkLegacyFiles"
-    ],
-    "post-install-cmd": [
-        ...,
-        "@legacy-scripts"
-    ],
-    "post-update-cmd": [
-        ...,
-        "@legacy-scripts"
-    ],
-}
+composer require --update-no-dev "ezsystems/legacy-bridge"
 ```
 
-Example: In the case of stock eZ Platform 1.13 that would specifically be:
-```
-"scripts": {
-    "legacy-scripts": [
-        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installAssets",
-        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installLegacyBundlesExtensions",
-        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::generateAutoloads",
-        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::symlinkLegacyFiles"
-    ],
-    "symfony-scripts": [
-        "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
-        "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
-        "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::clearCache",
-        "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
-        "@legacy-scripts",
-        "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::dumpAssets",
-        "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
-    ],
-    "post-install-cmd": [
-        "@symfony-scripts"
-    ],
-    "post-update-cmd": [
-        "@symfony-scripts"
-    ],
-    (...)
-```
-
-
-### Enable EzPublishLegacyBundle
+2. Enable `EzPublishLegacyBundle`
 Edit `app/AppKernel.php`, and add `new eZ\Bundle\EzPublishLegacyBundle\EzPublishLegacyBundle( $this ),`
-at the end of  the `$bundles` array. Pay close attention to the `$this` argument, LegacyBundle is a bit 
-spoiled and has high expectations from its collaborators ;)
+at the end of the `$bundles` array _(typically just after `new AppBundle\AppBundle(),`)_.
 
-### Add legacy routes
-Edit `app/config/routing.yml`, and add the LegacyBundle routes at the end of the file.
+_NOTE: Pay close attention to the `$this` argument, LegacyBundle needs it to interact with other eZ bundles._
 
+3. Run the following command to configure your install for legacy usage:
 ```
-# NOTE: Always keep at the end of the file so native symfony routes always have precendence, to avoid legacy
-# REST pattern overriding possible eZ Platform REST routes. 
-_ezpublishLegacyRoutes:
-    resource: @EzPublishLegacyBundle/Resources/config/routing.yml
+php app/console ezpublish:legacy:init
 ```
+
+During it's execution it will advice you on which command to run **after** you have moved over your legacy files
+_(extensions, settings and optionally designs)_.
+
+_TIP:_
+> If you are in need of applying these "init" steps manually, see INSTALL.md from a 1.4 or a 2.0 version of LegacyBridge.
+
 
 ### Enable legacy_mode for your backoffice siteaccess
 
 The Legacy Backoffice requires the `legacy_mode` option to be enabled.
-This can be done in app/config/config.yml or app/config/ezplatform.yml:
+
+This can be done in app/config/config.yml or app/config/ezplatform.yml, where `site_admin` is the name of the admin
+siteaccess:
 
 ```
 ez_publish_legacy:
@@ -92,17 +56,8 @@ ezpublish_setup:
 ```
 
 _Tip:_
-> Enabling Setup wizard is only needed if you intend to perform a new install with legacy demo data, you can also install Plaform data _(clean, demo)_ and afterwards when everything is setup use Platform UI to change Richtext FieldTypes to XmlText _(using [ezplatform-xmltext-fieldtype](https://github.com/ezsystems/ezplatform-xmltext-fieldtype))_, or install [Netgen RichTextDataType Bundle for legacy](https://github.com/netgen/NetgenRichTextDataTypeBundle) to make legacy allow raw editing of these. If you install eZ Platform Enterprise and it's demo data, there will also be Landing Page field type to handle in similar way _(contributions to Legacy Bridge on this more than welcome ;))_
+> Enabling Setup wizard is only needed if you intend to perform a new install with legacy demo data, you can also install Platform data _(clean, demo)_ and afterwards when everything is setup use Platform UI to change Richtext FieldTypes to XmlText _(using [ezplatform-xmltext-fieldtype](https://github.com/ezsystems/ezplatform-xmltext-fieldtype))_, or install [Netgen RichTextDataType Bundle for legacy](https://github.com/netgen/NetgenRichTextDataTypeBundle) to make legacy allow raw editing of these. If you install eZ Platform Enterprise and it's demo data, there will also be Landing Page field type to handle in similar way _(contributions to Legacy Bridge on this more than welcome ;))_
 
-
-### Install `ezsystems/legacy-bridge`
-
-
-Package can be installed using Composer in the following way:
-
-```
-composer require --update-no-dev "ezsystems/legacy-bridge:^1.5.0"
-```
 
 ### Optional: Add missing legacy extensions
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Installing the eZ Platform legacy bridge
 
-Instructions below will take you true installing legacy bridge and implicit legacy on top of a eZ Platform 1.13.x - 2.x
+Instructions below will take you through installing legacy bridge and implicit legacy on top of a eZ Platform 1.13.x - 2.x
 install.
 
 _TIP:_

--- a/bundle/Command/LegacyConfigurationCommand.php
+++ b/bundle/Command/LegacyConfigurationCommand.php
@@ -59,5 +59,6 @@ EOT
         $configurationDumper->dump($configurationConverter->fromLegacy($package, $adminSiteaccess), $options);
 
         $output->writeln('Configuration written to ezpublish.yml and environment related ezpublish configuration files.');
+        $output->writeln('Make sure to apply the config relevant to your install to you ezplatform.yml file.');
     }
 }

--- a/bundle/Command/LegacyConfigurationCommand.php
+++ b/bundle/Command/LegacyConfigurationCommand.php
@@ -59,6 +59,6 @@ EOT
         $configurationDumper->dump($configurationConverter->fromLegacy($package, $adminSiteaccess), $options);
 
         $output->writeln('Configuration written to ezpublish.yml and environment related ezpublish configuration files.');
-        $output->writeln('Make sure to apply the config relevant to your install to you ezplatform.yml file.');
+        $output->writeln('Make sure to apply the config relevant to your install to your ezplatform.yml file.');
     }
 }

--- a/bundle/Command/LegacyInitCommand.php
+++ b/bundle/Command/LegacyInitCommand.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * File containing the LegacySrcSymlinkCommand class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishLegacyBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+class LegacyInitCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('ezpublish:legacy:init')
+            ->setDefinition(
+                array(
+                    new InputArgument('src', InputArgument::OPTIONAL, 'The src directory for legacy files', 'src/legacy_files'),
+                )
+            )
+            ->setDescription('Inits folders you can use when migrating from eZ Publish install to eZ Platform with Legacy Bridge')
+            ->setHelp(
+                <<<EOT
+The command <info>%command.name%</info> creates the following folders for migration usage:
+- src/AppBundle/ezpublish_legacy => Optionaly for extensions you want to version in your project source (as opposed to install using composer)
+- src/legacy_files/design  => Optionally for custom designs not already made part of an extension
+- src/legacy_files/settings/override => Folder for override settings for legacy
+- src/legacy_files/settings/siteaccess => Folder for siteaccess settings for legacy
+
+
+<info>src/legacy_files</info> stored in your root project for
+any design/extension/settings project files, and symlinks these into <info>ezpublish_legacy/</info> which is installed by composer.
+
+The benefit of this is:
+1. Being able to version your design/extension/settings files in git without versioning legacy itself
+2. A predefined convention for where to place these files when migrating from older versions
+3. Placing these files directly in ezpublish_legacy folder will lead to them getting removed in some cases when composer
+   needs to completely replace ezpublish-legacy package for different reasons.
+
+<comment>NOTE: Once this is ran you'll get instructions on which commands to run to setup symlinks once you have populated the folders.</comment>
+EOT
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $srcArg = rtrim($input->getArgument('src'), '/');
+
+        /**
+         * @var \Symfony\Component\Filesystem\Filesystem
+         */
+        $filesystem = $this->getContainer()->get('filesystem');
+
+        $filesystem->mkdir([
+            $srcArg,
+            "$srcArg/design",
+            //"$srcArg/AppBundle",
+            "$srcArg/AppBundle/ezpublish_legacy",
+            "$srcArg/settings",
+            "$srcArg/settings/override",
+            "$srcArg/settings/siteaccess",
+        ]);
+
+        $output->writeln(<<<EOT
+
+The following folders should have been created (or where already present):
+- src/AppBundle/ezpublish_legacy  _(for extensions)_
+- src/legacy_files/design
+- src/legacy_files/settings/override
+- src/legacy_files/settings/siteaccess
+
+Move over files and directories from older installation and afterwards run the folling commands to setup symlinks into
+legacy install:
+- <info>ezpublish:legacy:symlink</info>
+- <info>ezpublish:legacybundles:install_extensions</info>
+- <info>ezpublish:legacy:assets_install</info>
+
+
+EOT
+);
+    }
+}

--- a/bundle/Command/LegacyInitCommand.php
+++ b/bundle/Command/LegacyInitCommand.php
@@ -12,7 +12,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
-use Symfony\Component\Filesystem\Filesystem;
 
 class LegacyInitCommand extends ContainerAwareCommand
 {
@@ -25,26 +24,24 @@ class LegacyInitCommand extends ContainerAwareCommand
                     new InputArgument('src', InputArgument::OPTIONAL, 'The src directory for legacy files', 'src/legacy_files'),
                 )
             )
-            ->setDescription('Inits folders you can use when migrating from eZ Publish install to eZ Platform with Legacy Bridge')
+            ->setDescription('Inits Platform installation for legacy usage')
             ->setHelp(
                 <<<EOT
-The command <info>%command.name%</info> creates the following folders for migration usage:
-- src/AppBundle/ezpublish_legacy => Optionaly for extensions you want to version in your project source (as opposed to install using composer)
-- src/legacy_files/design  => Optionally for custom designs not already made part of an extension
-- src/legacy_files/settings/override => Folder for override settings for legacy
-- src/legacy_files/settings/siteaccess => Folder for siteaccess settings for legacy
+The command <info>%command.name%</info> prepares install for use with eZ Publish legacy and LegacyBridge.
 
+1. It creates the following folders which can be safely versioned, and symlinks them into ezpublish_legacy folder on composer install/update:
+- <info>src/AppBundle/ezpublish_legacy</info> => Optionally for extensions you want to version in your project source (as opposed to install using composer)
+- <info>src/legacy_files/design</info>  => Optionally for custom designs not already made part of an extension
+- <info>src/legacy_files/settings/override</info> => Folder for override settings for legacy
+- <info>src/legacy_files/settings/siteaccess</info> => Folder for siteaccess settings for legacy
+<comment>NOTE: You'll get instructions on which commands to run to setup symlinks once you have populated the folders.</comment>
 
-<info>src/legacy_files</info> stored in your root project for
-any design/extension/settings project files, and symlinks these into <info>ezpublish_legacy/</info> which is installed by composer.
+2. It configures <info>@legacy-scrips</info> in composer.json to make sure all needed scripts are executed on <info>composer install/update</info>
 
-The benefit of this is:
-1. Being able to version your design/extension/settings files in git without versioning legacy itself
-2. A predefined convention for where to place these files when migrating from older versions
-3. Placing these files directly in ezpublish_legacy folder will lead to them getting removed in some cases when composer
-   needs to completely replace ezpublish-legacy package for different reasons.
+3. It enables <info>EzPublishLegacyBundle</info> and <info>XmlTextFieldTypeBundle</info> in <info>app/AppKernel.php</info> if needed
 
-<comment>NOTE: Once this is ran you'll get instructions on which commands to run to setup symlinks once you have populated the folders.</comment>
+4. It appends legacy routes to <info>app/config/routing.yml</info> if needed
+
 EOT
             );
     }
@@ -53,6 +50,19 @@ EOT
     {
         $this->createDirectories($input, $output);
         $this->updateComposeJson($output);
+        $this->enableBundles($output);
+        $this->enableRoutes($output);
+
+        $output->writeln(<<<'EOT'
+
+<options=bold,underscore>All steps completed!</options>
+
+You can now check changes done and start to move over any legacy files (see above).
+
+One done you can run the following command to setup symlinks, dump assets, (...):
+- <info>composer symfony-scripts</info>
+EOT
+        );
     }
 
     protected function createDirectories(InputInterface $input, OutputInterface $output)
@@ -74,21 +84,13 @@ EOT
             "$srcArg/settings/siteaccess",
         ]);
 
-        $output->writeln(<<<EOT
+        $output->writeln(<<<'EOT'
 
 The following folders should have been created (or where already present):
-- src/AppBundle/ezpublish_legacy  _(for extensions)_
-- src/legacy_files/design
-- src/legacy_files/settings/override
-- src/legacy_files/settings/siteaccess
-
-Move over files and directories from older installation and afterwards run the folling commands to setup symlinks into
-legacy install:
-- <info>ezpublish:legacy:symlink</info>
-- <info>ezpublish:legacybundles:install_extensions</info>
-- <info>ezpublish:legacy:assets_install</info>
-
-
+- <info>src/AppBundle/ezpublish_legacy</info>  (for extensions)
+- <info>src/legacy_files/design</info>  (optional if you have a design which is not provided by an extension)
+- <info>src/legacy_files/settings/override</info>
+- <info>src/legacy_files/settings/siteaccess</info>
 EOT
         );
     }
@@ -99,7 +101,7 @@ EOT
         $updateComposerJson = false;
         $composerJson = json_decode(file_get_contents('composer.json'), true);
         if ($composerJson === null) {
-            $errOutput->writeln('Error: Unable to parse composer.json');
+            $errOutput->writeln('<error>Error: Unable to parse composer.json</error>');
 
             return;
         }
@@ -118,13 +120,48 @@ EOT
         if (!array_key_exists('symfony-scripts', $composerJson['scripts'])) {
             $composerJson['scripts']['symfony-scripts'] = ['@legacy-scripts'];
             $updateComposerJson = true;
-        } elseif (!in_array('@legacy-scripts', $composerJson['scripts']['symfony-scripts'])) {
+            $errOutput->writeln(<<<'EOT'
+<error>Warning : Did not find a <info>symfony-scripts</info> section in composer.json, check
+source from eZ for how this is used and adapt your composer.json to take advantage.</error>
+
+Example for stock 2.x setup:
+<info>
+"scripts": {
+    "legacy-scripts": [
+        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installAssets",
+        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installLegacyBundlesExtensions",
+        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::generateAutoloads",
+        "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::symlinkLegacyFiles"
+    ],
+    "symfony-scripts": [
+        "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
+        "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::clearCache",
+        "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
+        "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
+        "@legacy-scripts",
+        "@php bin/console assetic:dump"
+    ],
+    "post-install-cmd": [
+        "@symfony-scripts"
+    ],
+    "post-update-cmd": [
+        "@symfony-scripts"
+    ],
+</info>
+EOT
+            );
+        } elseif (!\in_array('@legacy-scripts', $composerJson['scripts']['symfony-scripts'])) {
             $symfonyScripts = $composerJson['scripts']['symfony-scripts'];
+
             $offset = array_search('@php bin/console assetic:dump', $symfonyScripts);
+            if ($offset === false) {
+                // Fallback to 1.x version of the dump script is present instead in case of upgrade
+                $offset = array_search('eZ\Bundle\EzPublishCoreBundle\Composer\ScriptHandler::dumpAssets', $symfonyScripts);
+            }
 
             if ($offset === false) {
-                $errOutput->writeln('Warning : Unable to find "assetic:dump" in [symfony-scripts], putting "@legacy_scripts" at the end of array');
-                $offset = count($symfonyScripts);
+                $errOutput->writeln('Warning : Unable to find "assetic:dump / ScriptHandler::dumpAsset" in [symfony-scripts], putting "@legacy_scripts" at the end of array');
+                $offset = \count($symfonyScripts);
             }
 
             array_splice($symfonyScripts, $offset, 0, ['@legacy-scripts']);
@@ -134,6 +171,80 @@ EOT
 
         if ($updateComposerJson) {
             file_put_contents('composer.json', json_encode($composerJson, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) . PHP_EOL);
+        }
+    }
+
+    protected function enableBundles(OutputInterface $output)
+    {
+        $errOutput = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+        if (!$text = file_get_contents('app/AppKernel.php')) {
+            $errOutput->writeln('<error>Error: Unable to load app/AppKernel.php</error>');
+
+            return;
+        }
+
+        $changed = false;
+        $lines = preg_split('/\r\n|\r|\n/', $text);
+        $appOffset = false;
+        foreach ($lines as $i => $line) {
+            if (stripos($line, 'new AppBundle\AppBundle()') !== false) {
+                $appOffset = $i;
+                // Make sure element has comma (",") at end, however don't mark as $changed
+                if (stripos($line, 'new AppBundle\AppBundle(),') === false) {
+                    $lines[$i] = $line . ',';
+                }
+
+                break;
+            }
+        }
+
+        if (!$appOffset) {
+            $errOutput->writeln('<error>Error: Could not find "new AppBundle\AppBundle()" in app/AppKernel.php</error>');
+
+            return;
+        }
+
+        // Enable Bundles (if needed)
+        if (stripos($text, 'EzSystemsEzPlatformXmlTextFieldTypeBundle') === false) {
+            // Add XmlText bundle bundle before AppBundle (on purpose without indenting)
+            array_splice(
+                $lines,
+                trim($lines[$appOffset - 1]) === '// Application' ? $appOffset - 1 : $appOffset,
+                0,
+                'new EzSystems\EzPlatformXmlTextFieldTypeBundle\EzSystemsEzPlatformXmlTextFieldTypeBundle(),'
+                );
+            $changed = true;
+        }
+
+        if ($changed) {
+            file_put_contents('app/AppKernel.php', implode(PHP_EOL, $lines));
+        }
+    }
+
+    protected function enableRoutes(OutputInterface $output)
+    {
+        $errOutput = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+        if (!$text = file_get_contents('app/config/routing.yml')) {
+            $errOutput->writeln('<error>Error: Unable to load app/config/routing.yml</error>');
+
+            return;
+        }
+
+        $changed = false;
+        if (stripos($text, 'resource: @EzPublishLegacyBundle/Resources/config/routing.yml') === false) {
+            // Add routes to the end of routes file
+            $text .= <<<'EOT'
+
+# NOTE: ALWAYS keep this at the end of your routing rules so native symfony routes have precedence
+#       To avoid legacy REST pattern overriding possible eZ Platform REST routes and so on.
+_ezpublishLegacyRoutes:
+    resource: '@EzPublishLegacyBundle/Resources/config/routing.yml'
+EOT;
+            $changed = true;
+        }
+
+        if ($changed) {
+            file_put_contents('app/config/routing.yml', $text);
         }
     }
 }

--- a/bundle/Command/LegacyInitCommand.php
+++ b/bundle/Command/LegacyInitCommand.php
@@ -77,7 +77,6 @@ EOT
         $filesystem->mkdir([
             $srcArg,
             "$srcArg/design",
-            //"$srcArg/AppBundle",
             "$srcArg/AppBundle/ezpublish_legacy",
             "$srcArg/settings",
             "$srcArg/settings/override",

--- a/bundle/Command/LegacyInitCommand.php
+++ b/bundle/Command/LegacyInitCommand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the LegacySrcSymlinkCommand class.
+ * File containing the LegacyInitCommand class.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.

--- a/bundle/Command/LegacyInitCommand.php
+++ b/bundle/Command/LegacyInitCommand.php
@@ -86,7 +86,7 @@ EOT
 
         $output->writeln(<<<'EOT'
 
-The following folders should have been created (or where already present):
+The following folders should have been created (or were already present):
 - <info>src/AppBundle/ezpublish_legacy</info>  (for extensions)
 - <info>src/legacy_files/design</info>  (optional if you have a design which is not provided by an extension)
 - <info>src/legacy_files/settings/override</info>

--- a/bundle/Command/LegacyInitCommand.php
+++ b/bundle/Command/LegacyInitCommand.php
@@ -50,6 +50,11 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->createDirectories($input, $output);
+    }
+
+    protected function createDirectories(InputInterface $input, OutputInterface $output)
+    {
         $srcArg = rtrim($input->getArgument('src'), '/');
 
         /**
@@ -83,6 +88,6 @@ legacy install:
 
 
 EOT
-);
+        );
     }
 }

--- a/bundle/Command/LegacySrcSymlinkCommand.php
+++ b/bundle/Command/LegacySrcSymlinkCommand.php
@@ -27,7 +27,7 @@ class LegacySrcSymlinkCommand extends ContainerAwareCommand
                     new InputArgument('src', InputArgument::OPTIONAL, 'The src directory for legacy files', 'src/legacy_files'),
                 )
             )
-            ->addOption('create', 'c', InputOption::VALUE_NONE, 'Create "src" directory structure if it does not exist')
+            ->addOption('create', 'c', InputOption::VALUE_NONE, 'DEPRECATED: Use ezpublish:legacy:init instead!')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Force symlinking folders even if target already exists')
             ->setDescription('Installs legacy project settings and design files from "src" to corresponding folders in ezpublish_legacy/')
             ->setHelp(

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "ezsystems/ezpublish-legacy-installer": "^2.0.4",
         "ezsystems/ezpublish-legacy": "^2017.12",
         "ezsystems/ezpublish-kernel": "^6.13.4",
+        "ezsystems/ezplatform-xmltext-fieldtype": "^1.7",
         "sensio/distribution-bundle": "^3.0.36 | ^4.0.40 | ^5.0.22",
         "twig/twig": "^1.35 | ^2.5"
     },


### PR DESCRIPTION
In order to  simplify upgrades from pure legacy installs, this command is meant to be used like this to simplify install / upgrades _(in comparison to todays INSTALL.md, which does not cover upgrades, and is a bit more manual still)_:
- Enable bundle(s)
- (Optional) Edit config for legacy routes, & enable legacy mode for backend
- Install legacy bridge
- Run `init` which will:
  - [x] Generate all legacy related folders, and tell you which one is which and where to copy your files from eZ Publish
  - Adjust composer.json as current described in INSTALL doc automatically ?
    - [x] Add the composer legacy post-*-scripts
    - [x]  Enable EzPublishLegacyBundle
    - [x] Add legacy routes
    - ~Optional: Enable legacy_mode for your backoffice siteaccess~
    - ~Optional: add security rules for the Setup Wizard~
    - ~Optional: Ask user to install recommended extensions / bundles (search ext, richtext ext, ..)~
    - [x] Instruct user to run `composer run-script post-update-cmd` once things have been moved into folders, **or maybe rather `composer legacy-scripts`**
-  [x] Update INSTALL doc to reflect usage of this command.
