### PR TITLE
Update install doc for 2.0 to not remove dev deps

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -105,7 +105,7 @@ _Tip:_
 `ezsystems/legacy-bridge` contains a newer version of the libraries previously included in `ezsystems/ezpublish-kernel` in version 5.x.
 
 ```
-composer require --update-no-dev "ezsystems/legacy-bridge:^2.0"
+composer require --update-with-all-dependencies "ezsystems/legacy-bridge:^2.0"
 ```
 
 ### Recommended: Add additional Legacy <=> eZ Platform integrations


### PR DESCRIPTION
Following the current instructions on 2.x causes the following since SensioGeneratorBundle is in require-dev:
```
> eZ\Bundle\EzPublishCoreBundle\Composer\ScriptHandler::clearCache
PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\ClassNotFoundException:
Attempted to load class "SensioGeneratorBundle" from namespace "Sensio\Bundle\GeneratorBundle".
```

And since `--update-no-dev` practically removes dev dependencies that where installed during platform install.