### PR TITLE
EZP-29144: Make websiteToolbarAction's Response cacheable

### DIFF
--- a/bundle/Controller/WebsiteToolbarController.php
+++ b/bundle/Controller/WebsiteToolbarController.php
@@ -146,9 +146,7 @@ class WebsiteToolbarController extends Controller
             // reverse proxy caches the different possible variations of the
             // response as it can depend on user role for instance. X-User-Hash cannot
             // be used since the website toolbar can have Owner( Self ) Policy Limitation.
-            if ($request->headers->has('Cookie')) {
-                $response->setVary('Cookie');
-            }
+            $response->setVary('Cookie');
         }
 
         return $response;

--- a/bundle/Controller/WebsiteToolbarController.php
+++ b/bundle/Controller/WebsiteToolbarController.php
@@ -39,12 +39,24 @@ class WebsiteToolbarController extends Controller
     /** @var ContentPreviewHelper */
     private $previewHelper;
 
+    /** @var bool */
+    private $viewCache;
+
+    /** @var bool */
+    private $ttlCache;
+
+    /** @var int */
+    private $defaultTtl;
+
     public function __construct(
         EngineInterface $engine,
         ContentService $contentService,
         LocationService $locationService,
         AuthorizationCheckerInterface $authChecker,
         ContentPreviewHelper $previewHelper,
+        $viewCache,
+        $ttlCache,
+        $defaultTtl,
         CsrfTokenManagerInterface $csrfTokenManager = null
     ) {
         $this->legacyTemplateEngine = $engine;
@@ -53,6 +65,9 @@ class WebsiteToolbarController extends Controller
         $this->authChecker = $authChecker;
         $this->csrfTokenManager = $csrfTokenManager;
         $this->previewHelper = $previewHelper;
+        $this->viewCache = $viewCache;
+        $this->ttlCache = $ttlCache;
+        $this->defaultTtl = $defaultTtl;
     }
 
     /**
@@ -118,12 +133,12 @@ class WebsiteToolbarController extends Controller
     {
         $request = $this->getRequest();
         $response = new Response();
-        if ($this->getParameter('content.view_cache') === true) {
+        if ($this->viewCache === true) {
             $response->setPublic();
 
-            if ($this->getParameter('content.ttl_cache') === true) {
+            if ($this->ttlCache === true) {
                 $response->setSharedMaxAge(
-                    $this->getParameter('content.default_ttl')
+                    $this->defaultTtl
                 );
             }
 

--- a/bundle/Controller/WebsiteToolbarController.php
+++ b/bundle/Controller/WebsiteToolbarController.php
@@ -131,7 +131,6 @@ class WebsiteToolbarController extends Controller
      */
     protected function buildResponse()
     {
-        $request = $this->getRequest();
         $response = new Response();
         if ($this->viewCache === true) {
             $response->setPublic();

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -172,6 +172,9 @@ services:
             - "@ezpublish.api.service.location"
             - "@security.authorization_checker"
             - "@ezpublish.content_preview_helper"
+            - "$content.view_cache$"
+            - "$content.ttl_cache$"
+            - "$content.default_ttl$"
             - "@?security.csrf.token_manager"
 
     ezpublish_legacy.router:


### PR DESCRIPTION
JIRA issue: [EZP-29144](https://jira.ez.no/browse/EZP-29144)

> Currently, the cache related to Website Toolbar doesn't take into the account if someone is an owner of the viewed Content Object. This means that if someone who doesn't have content/edit permissions access views this Content Object first, then the owner won't have an option to edit that Content Object using Website Toolbar.

The following PR: https://github.com/ezsystems/DemoBundle/pull/194 fixes the issue in the Symfony stack by loading the Website Toolbar using ESI, so that it won't be cached alongside the rest of the page content ("Vary: X-User-Hash" is used there, which is wrong when we need to deal with Owner ( Self ) Policy Limitation).

This PR makes websiteToolbarAction's Response cacheable with "Vary: Cookie". I used the content cache parameters to determine the headers.