### PR TITLE
Update tag for preview cache

### DIFF
--- a/bundle/Cache/PersistenceCachePurger.php
+++ b/bundle/Cache/PersistenceCachePurger.php
@@ -167,8 +167,9 @@ class PersistenceCachePurger implements CacheClearerInterface
             return;
         }
 
+        // todo Once we can require 2.2.2+, simplify to just invalidate "content-{$contentId}-version-{$versionNo}"
         $this->cache->deleteItem("ez-content-version-info-${contentId}-${versionNo}");
-        $this->cache->invalidateTags(["content-{$contentId}-version-{$versionNo}"]);
+        $this->cache->invalidateTags(["content-${contentId}-version-list", "content-{$contentId}-version-{$versionNo}"]);
     }
 
     /**

--- a/bundle/Cache/PersistenceCachePurger.php
+++ b/bundle/Cache/PersistenceCachePurger.php
@@ -168,7 +168,7 @@ class PersistenceCachePurger implements CacheClearerInterface
         }
 
         $this->cache->deleteItem("ez-content-version-info-${contentId}-${versionNo}");
-        $this->cache->invalidateTags(["content-${contentId}-version-list"]);
+        $this->cache->invalidateTags(["content-{$contentId}-version-{$versionNo}"]);
     }
 
     /**

--- a/bundle/Tests/Cache/PersistenceCachePurgerTest.php
+++ b/bundle/Tests/Cache/PersistenceCachePurgerTest.php
@@ -404,7 +404,7 @@ class PersistenceCachePurgerTest extends TestCase
         $this->cacheService
             ->expects($this->once())
             ->method('invalidateTags')
-            ->with(["content-${contentId}-version-${versionNo}"]);
+            ->with(["content-${contentId}-version-list", "content-${contentId}-version-${versionNo}"]);
 
         $this->cachePurger->contentVersion($contentId, $versionNo);
     }

--- a/bundle/Tests/Cache/PersistenceCachePurgerTest.php
+++ b/bundle/Tests/Cache/PersistenceCachePurgerTest.php
@@ -389,4 +389,30 @@ class PersistenceCachePurgerTest extends TestCase
     {
         $this->cachePurger->user(new \stdClass());
     }
+
+    /**
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger::contentVersion
+     * @dataProvider getDataForTestClearVersionForOneContent
+     */
+    public function testClearVersionOfOneContent($contentId, $versionNo)
+    {
+        $this->cacheService
+            ->expects($this->once())
+            ->method('deleteItem')
+            ->with("ez-content-version-info-${contentId}-${versionNo}");
+
+        $this->cacheService
+            ->expects($this->once())
+            ->method('invalidateTags')
+            ->with(["content-${contentId}-version-${versionNo}"]);
+
+        $this->cachePurger->contentVersion($contentId, $versionNo);
+    }
+
+    public function getDataForTestClearVersionForOneContent()
+    {
+        return [
+            [18, 37],
+        ];
+    }
 }


### PR DESCRIPTION
The admin preview function does not display the draft content that is
currently being edited, this is because the preview cache is not purged,
and the preview function always fetches content from the view cache, 
refer to ezsystems/ezpublish-kernel#2396 for details.

To fix this issue, `PersistenceCachePurger.php::contentVersion()` has 
been changed to invalidate cache with the new tags.

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug**            | yes
| **New feature**    | no
| **Target version** | `v2.0.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.