### PR TITLE
Throw exception when module or view is not found.

### DIFF
--- a/bundle/EventListener/EzpModuleNotFoundToNotFoundListener.php
+++ b/bundle/EventListener/EzpModuleNotFoundToNotFoundListener.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * File containing the EzpModuleNotFoundToNotFoundListener class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishLegacyBundle\EventListener;
+
+use ezpModuleNotFound;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class EzpModuleNotFoundToNotFoundListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::EXCEPTION => ['onException', 512],
+        ];
+    }
+
+    public function onException(GetResponseForExceptionEvent $event)
+    {
+        if ($event->getException() instanceof ezpModuleNotFound) {
+            $event->setException(new NotFoundHttpException('Page Not Found', $event->getException()));
+        }
+    }
+}

--- a/bundle/EventListener/EzpModuleViewNotFoundToNotFoundListener.php
+++ b/bundle/EventListener/EzpModuleViewNotFoundToNotFoundListener.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * File containing the EzpModuleViewNotFoundToNotFoundListener class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishLegacyBundle\EventListener;
+
+use ezpModuleViewNotFound;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class EzpModuleViewNotFoundToNotFoundListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::EXCEPTION => ['onException', 512],
+        ];
+    }
+
+    public function onException(GetResponseForExceptionEvent $event)
+    {
+        if ($event->getException() instanceof ezpModuleViewNotFound) {
+            $event->setException(new NotFoundHttpException('Page Not Found', $event->getException()));
+        }
+    }
+}

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -330,3 +330,15 @@ services:
             - "%ezpublish.siteaccess.default%"
         tags:
             - { name: kernel.event_subscriber }
+
+    ezpublish_legacy.ezp_module_not_found_to_not_found_listener:
+        class: eZ\Bundle\EzPublishLegacyBundle\EventListener\EzpModuleNotFoundToNotFoundListener
+        public: false
+        tags:
+            - { name: kernel.event_subscriber }
+
+    ezpublish_legacy.ezp_module_view_not_found_to_not_found_listener:
+        class: eZ\Bundle\EzPublishLegacyBundle\EventListener\EzpModuleViewNotFoundToNotFoundListener
+        public: false
+        tags:
+            - { name: kernel.event_subscriber }

--- a/bundle/Tests/EventListener/EzpModuleNotFoundToNotFoundListenerTest.php
+++ b/bundle/Tests/EventListener/EzpModuleNotFoundToNotFoundListenerTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * File containing the EzpModuleNotFoundToNotFoundListener class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishLegacyBundle\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use ezpModuleNotFound;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use eZ\Bundle\EzPublishLegacyBundle\EventListener\EzpModuleNotFoundToNotFoundListener;
+
+class EzpModuleNotFoundToNotFoundListenerTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+    }
+
+    public function testGetSubscribedEvents()
+    {
+        $this->assertSame(
+            array(
+                KernelEvents::EXCEPTION => ['onException', 512],
+            ),
+            EzpModuleNotFoundToNotFoundListener::getSubscribedEvents()
+        );
+    }
+
+    public function testOnException()
+    {
+        $exception = new ezpModuleNotFound('module-name');
+        $request = $this->createMock(Request::class);
+        $event = new GetResponseForExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            $exception
+        );
+        $listener = new EzpModuleNotFoundToNotFoundListener();
+        $listener->onException($event);
+        $this->assertInstanceOf(NotFoundHttpException::class, $event->getException());
+        $this->assertSame($exception, $event->getException()->getPrevious());
+    }
+}

--- a/bundle/Tests/EventListener/EzpModuleViewNotFoundToNotFoundListenerTest.php
+++ b/bundle/Tests/EventListener/EzpModuleViewNotFoundToNotFoundListenerTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * File containing the EzpModuleViewNotFoundToNotFoundListener class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishLegacyBundle\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use ezpModuleViewNotFound;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use eZ\Bundle\EzPublishLegacyBundle\EventListener\EzpModuleViewNotFoundToNotFoundListener;
+
+class EzpModuleViewNotFoundToNotFoundListenerTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+    }
+
+    public function testGetSubscribedEvents()
+    {
+        $this->assertSame(
+            array(
+                KernelEvents::EXCEPTION => ['onException', 512],
+            ),
+            EzpModuleViewNotFoundToNotFoundListener::getSubscribedEvents()
+        );
+    }
+
+    public function testOnException()
+    {
+        $exception = new ezpModuleViewNotFound('module-name', 'view-name');
+        $request = $this->createMock(Request::class);
+        $event = new GetResponseForExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            $exception
+        );
+        $listener = new EzpModuleViewNotFoundToNotFoundListener();
+        $listener->onException($event);
+        $this->assertInstanceOf(NotFoundHttpException::class, $event->getException());
+        $this->assertSame($exception, $event->getException()->getPrevious());
+    }
+}


### PR DESCRIPTION
The legacy ezpublish does not return the 404 response code for any
request to a page that does not exist. It simply redirects all invalid
requests to the login page with a resonse code 200.

To fix this issue, method `ezpkernelweb::dispatchLoop()` has been
changed to throw exception when the requested module or view does not
exist. In order to redirect the invalid requests to a 404 error page,
the exception thrown by the legacy ezpublish needs to be converted to
`HttpNotFoundException`.

Refer to ezsystems/ezpublish-legacy#1379 for details.

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug**            | yes
| **New feature**    | no
| **Target version** | `v2.0.0`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | no

**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.