### PR TITLE
Fix SiteAccess mapping on inline legacy calls with default site access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
 branches:
   only:
     - master
+    - 1.4
 
 # setup requirements for running unit tests
 before_script:

--- a/bundle/LegacyMapper/SiteAccess.php
+++ b/bundle/LegacyMapper/SiteAccess.php
@@ -87,8 +87,9 @@ class SiteAccess implements EventSubscriberInterface
         } else {
             $semanticPathinfo = $request->attributes->get('semanticPathinfo', $pathinfo);
         }
+
         $pos = mb_strrpos($pathinfo, $semanticPathinfo);
-        if ($pathinfo != $semanticPathinfo && $pos !== false) {
+        if ($legacyAccessType !== eZSiteAccess::TYPE_DEFAULT && $pathinfo != $semanticPathinfo && $pos !== false) {
             if ($pos === 0) {
                 $pos = mb_strlen($pathinfo) + 1;
             }

--- a/bundle/Tests/Cache/PersistenceCachePurgerTest.php
+++ b/bundle/Tests/Cache/PersistenceCachePurgerTest.php
@@ -142,6 +142,7 @@ class PersistenceCachePurgerTest extends TestCase
     {
         $map = array(
             array('content', null),
+            array(['content', 'info', 'remoteId'], null),
             array('urlAlias', null),
             array('location', null),
         );

--- a/bundle/Tests/Cache/SwitchableHttpCachePurgerTest.php
+++ b/bundle/Tests/Cache/SwitchableHttpCachePurgerTest.php
@@ -7,7 +7,7 @@
  */
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\Cache;
 
-use eZ\Bundle\EzPublishLegacyBundle\Cache\SwitchableHttpCachePurger;
+use eZ\Bundle\EzPublishLegacyBundle\Cache\LegacySwitchableHttpCachePurger;
 use eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger;
 use PHPUnit\Framework\TestCase;
 
@@ -22,7 +22,7 @@ class SwitchableHttpCachePurgerTest extends TestCase
     public function setUp()
     {
         $this->gatewayCachePurgerMock = $this->createMock(GatewayCachePurger::class);
-        $this->httpCachePurger = new SwitchableHttpCachePurger($this->gatewayCachePurgerMock);
+        $this->httpCachePurger = new LegacySwitchableHttpCachePurger($this->gatewayCachePurgerMock);
     }
 
     public function testPurgeSwitchedOn()

--- a/bundle/Tests/DependencyInjection/EzPublishLegacyExtensionTest.php
+++ b/bundle/Tests/DependencyInjection/EzPublishLegacyExtensionTest.php
@@ -22,6 +22,13 @@ class EzPublishLegacyExtensionTest extends AbstractExtensionTestCase
         );
     }
 
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->setParameter('kernel.bundles', []);
+    }
+
     public function testBundleNotEnabled()
     {
         $this->load(['enabled' => false]);

--- a/bundle/Tests/SiteAccess/LegacyMapperTest.php
+++ b/bundle/Tests/SiteAccess/LegacyMapperTest.php
@@ -99,6 +99,7 @@ class LegacyMapperTest extends LegacyBasedTestCase
 
     public function siteAccessMatchProvider()
     {
+        // args: $pathinfo, $semanticPathinfo, $siteaccess, $expectedAccess
         return array(
             array(
                 '/some/pathinfo',
@@ -297,6 +298,16 @@ class LegacyMapperTest extends LegacyBasedTestCase
                 array(
                     'name' => 'foo',
                     'type' => 10,
+                    'uri_part' => array(),
+                ),
+            ),
+            array(
+                '/_fragment',
+                '/',
+                new SiteAccess('site', 'default'),
+                array(
+                    'name' => 'site',
+                    'type' => 1,
                     'uri_part' => array(),
                 ),
             ),


### PR DESCRIPTION
_Also enable travis for 1.4 and fix regressions in unit tests since it last ran last fall._