### PR TITLE
Check if legacy engine is set before calling it

### DIFF
--- a/mvc/Templating/Twig/Environment.php
+++ b/mvc/Templating/Twig/Environment.php
@@ -38,7 +38,7 @@ class Environment extends Twig_Environment
             return $this->legacyTemplatesCache[$name];
         }
 
-        if (is_string($name) && $this->legacyEngine->supports($name)) {
+        if (is_string($name) && $this->legacyEngine !== null && $this->legacyEngine->supports($name)) {
             if (!$this->legacyEngine->exists($name)) {
                 throw new Twig_Error_Loader("Unable to find the template \"$name\"");
             }


### PR DESCRIPTION
On PHP 7.3, `loadTemplate` method is somehow called before `setEzLegacyEngine` had a chance to set the legacy engine to the `Environment` class. Checking for `null` on `$this->legacyEngine` does the job apparently, with no side-effects.