### PR TITLE
Follow-up EZP-29144: Handle missing LocationID and semanticPathInfo

### DIFF
--- a/bundle/Controller/WebsiteToolbarController.php
+++ b/bundle/Controller/WebsiteToolbarController.php
@@ -80,7 +80,7 @@ class WebsiteToolbarController extends Controller
      *
      * @return Response
      */
-    public function websiteToolbarAction($locationId, Request $request)
+    public function websiteToolbarAction($locationId = null, $originalSemanticPathInfo = '', Request $request)
     {
         $response = $this->buildResponse();
 
@@ -105,7 +105,7 @@ class WebsiteToolbarController extends Controller
             $template = 'design:parts/website_toolbar.tpl';
             $parameters = array(
                 'current_node_id' => $locationId,
-                'redirect_uri' => $request->attributes->get('semanticPathinfo'),
+                'redirect_uri' => $originalSemanticPathInfo ? $originalSemanticPathInfo : $request->attributes->get('semanticPathinfo'),
             );
         }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29144](https://jira.ez.no/browse/EZP-29144)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.4`
| **BC breaks**      | no
| **Doc needed**     | yes (?)

This PR is a followup for https://github.com/ezsystems/LegacyBridge/pull/152. Since parameters passed to `render_esi` needs to be serializable, and in some cases `null` is passed there, it ends with the exception in application logs:
```
request.CRITICAL: Uncaught PHP Exception RuntimeException: "Controller "eZ\Bundle\EzPublishLegacyBundle\Controller\WebsiteToolbarController::websiteToolbarAction()" requires that you provide a value for the "$locationId" argument (because there is no default value or because there is a non optional argument after this one)." at [...path deleted...]\ezpublish\cache\prod\classes.php line 2233 {"exception":"[object] (RuntimeException(code: 0): Controller \"eZ\\Bundle\\EzPublishLegacyBundle\\Controller\\WebsiteToolbarController::websiteToolbarAction()\" requires that you provide a value for the \"$locationId\" argument (because there is no default value or because there is a non optional argument after this one). at [...path deleted...]\\ezpublish\\cache\\prod\\classes.php:2233)"} []
```

This PR introduces new default value for `$locationId` controller arguments and new additional argument, which is necessary for using WebsiteToolbar through `render_esi`. 

Relevant PR on DemoBundle can be found here: https://github.com/ezsystems/DemoBundle/pull/195