### PR TITLE
Fix CORS OPTIONS Call for POST REST requests

### DIFF
--- a/bundle/Cache/PersistenceCachePurger.php
+++ b/bundle/Cache/PersistenceCachePurger.php
@@ -131,6 +131,7 @@ class PersistenceCachePurger implements CacheClearerInterface
 
             $tags[] = 'location-' . $id;
             $tags[] = 'urlAlias-location-' . $id;
+            $tags[] = 'urlAlias-location-path-' . $id;
 
             if (empty($contentIds)) {
                 // if caller did not provide affected content id's, then try to load location to get it

--- a/bundle/Routing/DefaultRouter.php
+++ b/bundle/Routing/DefaultRouter.php
@@ -28,6 +28,7 @@ class DefaultRouter extends BaseRouter
 
     public function matchRequest(Request $request)
     {
+        $this->setContext($this->context->fromRequest($request));
         $attributes = parent::matchRequest($request);
 
         if (


### PR DESCRIPTION
I have found that all OPTIONS calls for POST REST requests return 405 error message, this is due to the fact that DefaultRouter uses Symfony's default RequestContext which refers to a GET request. Therefore I'm setting the the RequestContext given the Request Object.