### PR TITLE
 [Optimization] Skip loading user and path if not needed

### DIFF
--- a/bundle/LegacyMapper/Configuration.php
+++ b/bundle/LegacyMapper/Configuration.php
@@ -297,16 +297,7 @@ class Configuration implements EventSubscriberInterface
             return $result;
         }
 
-        $pathPrefix = '';
-
-        try {
-            $pathPrefix = trim($this->urlAliasGenerator->getPathPrefixByRootLocationId($rootLocationId), '/');
-        } catch (Exception $e) {
-            // Ignore any errors
-            // Most probable cause for error is database not being ready yet,
-            // i.e. initial install of the project which includes eZ Publish Legacy
-        }
-
+        $pathPrefix = $this->loadPathPrefix($rootLocationId);
         $pathPrefixExcludeItems = array_map(
             static function ($value) {
                 return trim($value, '/');
@@ -339,5 +330,23 @@ class Configuration implements EventSubscriberInterface
         }
 
         return $clusterSettings;
+    }
+
+    private function loadPathPrefix($rootLocationId)
+    {
+        // If root location is 2 we know path is empty, so we can skip loading location + urlAlias data
+        if ($rootLocationId === 2) {
+            return '';
+        }
+
+        try {
+            return trim($this->urlAliasGenerator->getPathPrefixByRootLocationId($rootLocationId), '/');
+        } catch (Exception $e) {
+            // Ignore any errors
+            // Most probable cause for error is database not being ready yet,
+            // i.e. initial install of the project which includes eZ Publish Legacy
+        }
+
+        return '';
     }
 }


### PR DESCRIPTION
Some optimizations to reduce default Repo lookups by bridge from 11 to 3 cache lookups , this also avoids the serialization and mapping of these objects to API objects and logic around that.