### PR TITLE
Make Assetic integration optional

### DIFF
--- a/bundle/DependencyInjection/EzPublishLegacyExtension.php
+++ b/bundle/DependencyInjection/EzPublishLegacyExtension.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection;
 
+use Assetic\Factory\Loader\FormulaLoaderInterface;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ConfigurationProcessor;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -41,6 +42,10 @@ class EzPublishLegacyExtension extends Extension
 
         // Templating
         $loader->load('templating.yml');
+
+        if (interface_exists(FormulaLoaderInterface::class)) {
+            $loader->load('assetic.yml');
+        }
 
         // View
         $loader->load('view.yml');

--- a/bundle/Resources/config/assetic.yml
+++ b/bundle/Resources/config/assetic.yml
@@ -1,0 +1,6 @@
+services:
+    assetic.eztpl_formula_loader:
+        class: eZ\Publish\Core\MVC\Legacy\Templating\LegacyFormulaLoader
+        public: false
+        tags:
+            - {name: assetic.formula_loader, alias: eztpl}

--- a/bundle/Resources/config/templating.yml
+++ b/bundle/Resources/config/templating.yml
@@ -73,12 +73,6 @@ services:
         public: false
         arguments: ["@ezpublish_legacy.kernel", "@ezpublish_legacy.templating.object_converter"]
 
-    assetic.eztpl_formula_loader:
-        class: eZ\Publish\Core\MVC\Legacy\Templating\LegacyFormulaLoader
-        public: false
-        tags:
-            - {name: assetic.formula_loader, alias: eztpl}
-
     twig.loader.string:
         class: eZ\Publish\Core\MVC\Legacy\Templating\Twig\LoaderString
         public: false


### PR DESCRIPTION
In cases when Assetic is not present (e.g. eZ Platform 2.5) and after updating to PHP 7.3.7 you will get an exception:

```
PHP Fatal error:  During class fetch: Uncaught ReflectionException: Class Assetic\Factory\Loader\FormulaLoaderInterface not found in vendor/ezsystems/legacy-bridge/mvc/Templating/LegacyFormulaLoader.php:18
Stack trace:
#0 vendor/symfony/symfony/src/Symfony/Component/Debug/DebugClassLoader.php(156): require('vendor/asset...')
#1 [internal function]: Symfony\Component\Debug\DebugClassLoader->loadClass('eZ\\Publish\\Core...')
#2 [internal function]: spl_autoload_call('eZ\\Publish\\Core...')
#3 vendor/symfony/symfony/src/Symfony/Component/Config/Resource/ClassExistenceResource.php(78): class_exists('eZ\\Publish\\Core...')
#4 vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/ContainerBuilder.php(371): Symfony\Component\Config\Resource\ClassExistenceResource->isFresh(0)
#5 vendor/symfony/symfony/src/Symfony/Component/DependencyInject in vendor/ezsystems/legacy-bridge/mvc/Templating/LegacyFormulaLoader.php on line 18
```

This is due to fixing https://bugs.php.net/bug.php?id=76980

This PR fixes it by making the Assetic integration optional, based on existence of `Assetic\Factory\Loader\FormulaLoaderInterface` interface.