### PR TITLE
Detect legacy extensions by presence of ezinfo.php also

### DIFF
--- a/bundle/LegacyBundles/LegacyExtensionsLocator.php
+++ b/bundle/LegacyBundles/LegacyExtensionsLocator.php
@@ -29,7 +29,7 @@ class LegacyExtensionsLocator implements LegacyExtensionsLocatorInterface
                 continue;
             }
 
-            if (file_exists($item->getPathname() . '/extension.xml')) {
+            if (file_exists($item->getPathname() . '/ezinfo.php') || file_exists($item->getPathname() . '/extension.xml')) {
                 $return[] = $item->getPathname();
             }
         }


### PR DESCRIPTION
For upgrades it's common extensions just have `ezinfo.php` in root, and as `extension.xml` is optional in ezpublish-legacy we should accept both here. Even if the former where deprecated in favour of the latter at some point.