### PR TITLE
Reset the session key for session attributes to a default Symfony value

### DIFF
--- a/bundle/Resources/config/default_settings.yml
+++ b/bundle/Resources/config/default_settings.yml
@@ -9,3 +9,13 @@ parameters:
 
     # Whether to use legacy mode or not. If true, will let the legacy kernel handle url aliases.
     ezsettings.default.legacy_mode: false
+
+    # Override to fix eZ Publish Legacy session namespace. Since Symfony 3.4.39 attribute bag service
+    # is not injected into session any more (https://github.com/symfony/symfony/pull/36063), making the bag
+    # use the default session key, while previously it was customized in eZ kernel.
+    # https://github.com/ezsystems/ezpublish-kernel/blob/7.5/eZ/Bundle/EzPublishCoreBundle/Resources/config/session.yml#L21
+    # This somehow has the effect on login pages when legacy admin UI is ran in "legacy_mode: false"
+    # (e.g. Netgen Admin UI), where the first redirect after a login shows a secondary login form.
+    # This resets the session key to a default value in Symfony, making sure it is compatible
+    # with both previous versions of Symfony as well as 3.4.39+
+    ezpublish.session.attribute_bag.storage_key: "_sf2_attributes"


### PR DESCRIPTION
Without this, on Symfony 3.4.39 (since https://github.com/symfony/symfony/pull/36063), after logging into Netgen Admin UI, user is presented with an erroneous secondary login form, since now eZ Publish Legacy and Symfony use different session keys for session attribute storage, making the sessions incompatible:

![image](https://user-images.githubusercontent.com/362286/78649679-10407300-78be-11ea-8d26-939b300a58db.png)

After refreshing the page, everything works fine, but this fixes the issue completely by making sure that the sessions are compatible again after 3.4.39. It should also be fully backwards compatible with previous Symfony versions.

This could've maybe gone into Netgen Admin UI repo, but I feel this is a more generic fix and this is a more correct location for the fix.
