### PR TITLE
Fix EZP-30857: Referenced image file is not deleted from storage when removing draft, archived or published version.

### DIFF
--- a/bundle/Resources/config/fieldtype_services.yml
+++ b/bundle/Resources/config/fieldtype_services.yml
@@ -4,5 +4,6 @@ services:
         arguments:
             - "@ezpublish.image_alias.imagine.alias_cleaner"
             - "@ezpublish.core.io.image_fieldtype.legacy_url_redecorator"
+            - "@ezpublish.fieldType.ezimage.io_service"
         lazy: true
         public: false

--- a/mvc/Image/AliasCleaner.php
+++ b/mvc/Image/AliasCleaner.php
@@ -7,6 +7,7 @@
 namespace eZ\Publish\Core\MVC\Legacy\Image;
 
 use eZ\Publish\Core\FieldType\Image\AliasCleanerInterface;
+use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\Core\IO\UrlRedecoratorInterface;
 
 class AliasCleaner implements AliasCleanerInterface
@@ -21,18 +22,25 @@ class AliasCleaner implements AliasCleanerInterface
      */
     private $urlRedecorator;
 
+    /**
+     * @var IOServiceInterface
+     */
+    private $IOService;
+
     public function __construct(
         AliasCleanerInterface $innerAliasCleaner,
-        UrlRedecoratorInterface $urlRedecorator
+        UrlRedecoratorInterface $urlRedecorator,
+        IOServiceInterface $IOService
     ) {
         $this->innerAliasCleaner = $innerAliasCleaner;
         $this->urlRedecorator = $urlRedecorator;
+        $this->IOService = $IOService;
     }
 
     public function removeAliases($originalPath)
     {
-        $this->innerAliasCleaner->removeAliases(
-            $this->urlRedecorator->redecorateFromTarget($originalPath)
-        );
+        $uri = $this->urlRedecorator->redecorateFromTarget($originalPath);
+        $binaryFile = $this->IOService->loadBinaryFileByUri($uri);
+        $this->innerAliasCleaner->removeAliases($binaryFile->id);
     }
 }

--- a/mvc/Tests/Image/AliasCleanerTest.php
+++ b/mvc/Tests/Image/AliasCleanerTest.php
@@ -6,6 +6,8 @@
  */
 namespace eZ\Publish\Core\MVC\Legacy\Tests\Image;
 
+use eZ\Publish\Core\IO\IOServiceInterface;
+use eZ\Publish\Core\IO\Values\BinaryFile;
 use eZ\Publish\Core\MVC\Legacy\Image\AliasCleaner;
 use eZ\Publish\Core\FieldType\Image\AliasCleanerInterface;
 use eZ\Publish\Core\IO\UrlRedecoratorInterface;
@@ -28,22 +30,36 @@ class AliasCleanerTest extends TestCase
      */
     private $urlRedecorator;
 
+    /**
+     * @var \eZ\Publish\Core\IO\IOServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $IOService;
+
     protected function setUp()
     {
         parent::setUp();
         $this->innerAliasCleaner = $this->createMock(AliasCleanerInterface::class);
         $this->urlRedecorator = $this->createMock(UrlRedecoratorInterface::class);
-        $this->aliasCleaner = new AliasCleaner($this->innerAliasCleaner, $this->urlRedecorator);
+        $this->IOService = $this->createMock(IOServiceInterface::class);
+        $this->aliasCleaner = new AliasCleaner($this->innerAliasCleaner, $this->urlRedecorator, $this->IOService);
     }
 
     public function testRemoveAliases()
     {
-        $originalPath = 'foo/bar/test.jpg';
+        $originalPath = 'var/storage/image/foo/bar/test.jpg';
+        $uri = '/var/storage/image/foo/bar/test.jpg';
+        $binaryFile = new BinaryFile(['id' => 'foo/bar/test.jpg']);
 
         $this->urlRedecorator
             ->expects($this->once())
             ->method('redecorateFromTarget')
-            ->with($originalPath);
+            ->with($originalPath)
+            ->willReturn($uri);
+
+        $this->IOService
+            ->expects($this->once())
+            ->method('loadBinaryFileByUri')
+            ->willReturn($binaryFile);
 
         $this->innerAliasCleaner
             ->expects($this->once())


### PR DESCRIPTION
Fix https://issues.ibexa.co/browse/EZP-30857 also for legacy backend