### PR TITLE
IBX-1136: Prevent legacy and symfony clear:cache script from clearing SPI cache

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -118,3 +118,23 @@ rewrite "^/var/storage/packages/(.*)" "/var/storage/packages/$1" break;
 Last step, if you are on *nix operation system, is to make sure to run
 the appropriate command for setting correct folder permissions, you
 can find the information you need in [installation guide for eZ Platform](https://doc.ezplatform.com/en/latest/getting_started/install_ez_platform/).
+
+### Clearing of cache
+
+Legacy bridge will by default also clear SPI cache ( stored in redis, memcached or disk) when content-view cache is
+cleared in legacy. This behaviour can be disabled using the setting:
+
+```
+// app/config/ezplatform.yml
+ez_publish_legacy:
+    clear_all_spi_cache_from_legacy: false
+```
+
+Legacy bridge will also alter the default behaviour of Symfony's `bin/console cache:clear` command so that SPI cache
+is cleared when it is executed. This behaviour can be disabled using the setting:
+
+```
+// app/config/ezplatform.yml
+ez_publish_legacy:
+    clear_all_spi_cache_on_symfony_clear_cache: false
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -121,7 +121,7 @@ can find the information you need in [installation guide for eZ Platform](https:
 
 ### Clearing of cache
 
-Legacy bridge will by default also clear SPI cache ( stored in redis, memcached or disk) when content-view cache is
+Legacy bridge will by default also clear SPI cache (stored in redis, memcached or disk) when content-view cache is
 cleared in legacy. This behaviour can be disabled using the setting:
 
 ```

--- a/bundle/Cache/PersistenceCachePurger.php
+++ b/bundle/Cache/PersistenceCachePurger.php
@@ -243,9 +243,11 @@ class PersistenceCachePurger implements CacheClearerInterface
         }
 
         if ($id === null) {
-            $this->cache->invalidateTags([
-                $this->cacheIdentifierGenerator->generateTag(self::TYPE_MAP_IDENTIFIER),
-            ]);
+            if ($this->clearAllSPICacheFromLegacy) {
+                $this->cache->invalidateTags([
+                    $this->cacheIdentifierGenerator->generateTag(self::TYPE_MAP_IDENTIFIER),
+                ]);
+            }
         } elseif (is_scalar($id)) {
             $this->cache->invalidateTags([
                 $this->cacheIdentifierGenerator->generateTag(self::TYPE_IDENTIFIER, [$id]),

--- a/bundle/Cache/PersistenceCachePurger.php
+++ b/bundle/Cache/PersistenceCachePurger.php
@@ -103,7 +103,7 @@ class PersistenceCachePurger implements CacheClearerInterface
      *
      * Sets a internal flag 'allCleared' to avoid clearing cache several times
      */
-    protected function flushSpiCache()
+    private function flushSpiCache()
     {
         if ($this->isSwitchedOff()) {
             return;

--- a/bundle/Cache/PersistenceCachePurger.php
+++ b/bundle/Cache/PersistenceCachePurger.php
@@ -7,6 +7,7 @@
 namespace eZ\Bundle\EzPublishLegacyBundle\Cache;
 
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandlerInterface;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
@@ -30,6 +31,8 @@ class PersistenceCachePurger implements CacheClearerInterface
     private const SECTION_IDENTIFIER = 'section';
     private const LANGUAGE_IDENTIFIER = 'language';
     private const USER_IDENTIFIER = 'user';
+
+    use ContainerAwareTrait;
 
     use Switchable;
 
@@ -73,13 +76,23 @@ class PersistenceCachePurger implements CacheClearerInterface
     }
 
     /**
-     * Clear all persistence cache.
+     * Clear all persistence cache if that is allowed by config.
      *
      * In legacy kernel used when user presses clear all cache button in admin interface.
+     */
+    public function all()
+    {
+        if ($this->container->getParameter('ezpublish_legacy.clear_all_spi_cache_from_legacy')) {
+            $this->flushSpiCache();
+        }
+    }
+
+    /**
+     * Clear all persistence cache.
      *
      * Sets a internal flag 'allCleared' to avoid clearing cache several times
      */
-    public function all()
+    protected function flushSpiCache()
     {
         if ($this->isSwitchedOff()) {
             return;
@@ -358,6 +371,8 @@ class PersistenceCachePurger implements CacheClearerInterface
      */
     public function clear($cacheDir)
     {
-        $this->all();
+        if ($this->container->getParameter('ezpublish_legacy.clear_all_spi_cache_on_symfony_clear_cache')) {
+            $this->flushSpiCache();
+        }
     }
 }

--- a/bundle/Cache/PersistenceCachePurger.php
+++ b/bundle/Cache/PersistenceCachePurger.php
@@ -63,7 +63,7 @@ class PersistenceCachePurger implements CacheClearerInterface
     /**
      * @var bool
      */
-    private $clearAllSpiCacheFromLegacy;
+    private $clearAllSPICacheFromLegacy;
 
     /**
      * Setups current handler with everything needed.
@@ -77,13 +77,13 @@ class PersistenceCachePurger implements CacheClearerInterface
         LocationHandlerInterface $locationHandler,
         CacheIdentifierGeneratorInterface $cacheIdentifierGenerator,
         bool $clearAllSPICacheOnSymfonyClearCache = true,
-        bool $clearAllSpiCacheFromLegacy = true
+        bool $clearAllSPICacheFromLegacy = true
     ) {
         $this->cache = $cache;
         $this->locationHandler = $locationHandler;
         $this->cacheIdentifierGenerator = $cacheIdentifierGenerator;
         $this->clearAllSPICacheOnSymfonyClearCache = $clearAllSPICacheOnSymfonyClearCache;
-        $this->clearAllSpiCacheFromLegacy = $clearAllSpiCacheFromLegacy;
+        $this->clearAllSPICacheFromLegacy = $clearAllSPICacheFromLegacy;
     }
 
     /**
@@ -93,8 +93,8 @@ class PersistenceCachePurger implements CacheClearerInterface
      */
     public function all()
     {
-        if ($this->clearAllSpiCacheFromLegacy) {
-            $this->flushSpiCache();
+        if ($this->clearAllSPICacheFromLegacy) {
+            $this->flushSPICache();
         }
     }
 
@@ -103,7 +103,7 @@ class PersistenceCachePurger implements CacheClearerInterface
      *
      * Sets a internal flag 'allCleared' to avoid clearing cache several times
      */
-    private function flushSpiCache()
+    private function flushSPICache()
     {
         if ($this->isSwitchedOff()) {
             return;
@@ -383,7 +383,7 @@ class PersistenceCachePurger implements CacheClearerInterface
     public function clear($cacheDir)
     {
         if ($this->clearAllSPICacheOnSymfonyClearCache) {
-            $this->flushSpiCache();
+            $this->flushSPICache();
         }
     }
 }

--- a/bundle/Cache/PersistenceCachePurger.php
+++ b/bundle/Cache/PersistenceCachePurger.php
@@ -7,7 +7,6 @@
 namespace eZ\Bundle\EzPublishLegacyBundle\Cache;
 
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandlerInterface;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
@@ -31,8 +30,6 @@ class PersistenceCachePurger implements CacheClearerInterface
     private const SECTION_IDENTIFIER = 'section';
     private const LANGUAGE_IDENTIFIER = 'language';
     private const USER_IDENTIFIER = 'user';
-
-    use ContainerAwareTrait;
 
     use Switchable;
 
@@ -59,6 +56,16 @@ class PersistenceCachePurger implements CacheClearerInterface
     protected $allCleared = false;
 
     /**
+     * @var bool
+     */
+    private $clearAllSPICacheOnSymfonyClearCache;
+
+    /**
+     * @var bool
+     */
+    private $clearAllSpiCacheFromLegacy;
+
+    /**
      * Setups current handler with everything needed.
      *
      * @param \Symfony\Component\Cache\Adapter\TagAwareAdapterInterface $cache
@@ -68,11 +75,15 @@ class PersistenceCachePurger implements CacheClearerInterface
     public function __construct(
         TagAwareAdapterInterface $cache,
         LocationHandlerInterface $locationHandler,
-        CacheIdentifierGeneratorInterface $cacheIdentifierGenerator
+        CacheIdentifierGeneratorInterface $cacheIdentifierGenerator,
+        bool $clearAllSPICacheOnSymfonyClearCache = true,
+        bool $clearAllSpiCacheFromLegacy = true
     ) {
         $this->cache = $cache;
         $this->locationHandler = $locationHandler;
         $this->cacheIdentifierGenerator = $cacheIdentifierGenerator;
+        $this->clearAllSPICacheOnSymfonyClearCache = $clearAllSPICacheOnSymfonyClearCache;
+        $this->clearAllSpiCacheFromLegacy = $clearAllSpiCacheFromLegacy;
     }
 
     /**
@@ -82,7 +93,7 @@ class PersistenceCachePurger implements CacheClearerInterface
      */
     public function all()
     {
-        if ($this->container->getParameter('ezpublish_legacy.clear_all_spi_cache_from_legacy')) {
+        if ($this->clearAllSpiCacheFromLegacy) {
             $this->flushSpiCache();
         }
     }
@@ -371,7 +382,7 @@ class PersistenceCachePurger implements CacheClearerInterface
      */
     public function clear($cacheDir)
     {
-        if ($this->container->getParameter('ezpublish_legacy.clear_all_spi_cache_on_symfony_clear_cache')) {
+        if ($this->clearAllSPICacheOnSymfonyClearCache) {
             $this->flushSpiCache();
         }
     }

--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -19,6 +19,8 @@ class Configuration extends SiteAccessConfiguration
         $rootNode
             ->children()
                 ->booleanNode('enabled')->defaultTrue()->end()
+                ->booleanNode('clear_all_spi_cache_on_symfony_clear_cache')->defaultTrue()->end()
+                ->booleanNode('clear_all_spi_cache_from_legacy')->defaultTrue()->end()
                 ->scalarNode('root_dir')
                     ->validate()
                         ->ifTrue(

--- a/bundle/DependencyInjection/EzPublishLegacyExtension.php
+++ b/bundle/DependencyInjection/EzPublishLegacyExtension.php
@@ -39,11 +39,17 @@ class EzPublishLegacyExtension extends Extension
         }
 
         if (isset($config['clear_all_spi_cache_on_symfony_clear_cache'])) {
-            $container->setParameter('ezpublish_legacy.clear_all_spi_cache_on_symfony_clear_cache', $config['clear_all_spi_cache_on_symfony_clear_cache']);
+            $container->setParameter(
+                'ezpublish_legacy.clear_all_spi_cache_on_symfony_clear_cache',
+                $config['clear_all_spi_cache_on_symfony_clear_cache']
+            );
         }
 
         if (isset($config['clear_all_spi_cache_from_legacy'])) {
-            $container->setParameter('ezpublish_legacy.clear_all_spi_cache_from_legacy', $config['clear_all_spi_cache_from_legacy']);
+            $container->setParameter(
+                'ezpublish_legacy.clear_all_spi_cache_from_legacy',
+                $config['clear_all_spi_cache_from_legacy']
+            );
         }
 
         // Templating

--- a/bundle/DependencyInjection/EzPublishLegacyExtension.php
+++ b/bundle/DependencyInjection/EzPublishLegacyExtension.php
@@ -38,6 +38,14 @@ class EzPublishLegacyExtension extends Extension
             $container->setParameter('ezpublish_legacy.root_dir', $config['root_dir']);
         }
 
+        if (isset($config['clear_all_spi_cache_on_symfony_clear_cache'])) {
+            $container->setParameter('ezpublish_legacy.clear_all_spi_cache_on_symfony_clear_cache', $config['clear_all_spi_cache_on_symfony_clear_cache']);
+        }
+
+        if (isset($config['clear_all_spi_cache_from_legacy'])) {
+            $container->setParameter('ezpublish_legacy.clear_all_spi_cache_from_legacy', $config['clear_all_spi_cache_from_legacy']);
+        }
+
         // Templating
         $loader->load('templating.yml');
 

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -222,6 +222,8 @@ services:
     ezpublish_legacy.persistence_cache_purger:
         class: eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger
         public: false
+        calls:
+            - [setContainer, ["@service_container"]]
         arguments:
             - "@ezpublish.cache_pool"
             - "@ezpublish.spi.persistence.cache.locationHandler"

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -222,12 +222,12 @@ services:
     ezpublish_legacy.persistence_cache_purger:
         class: eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger
         public: false
-        calls:
-            - [setContainer, ["@service_container"]]
         arguments:
             - "@ezpublish.cache_pool"
             - "@ezpublish.spi.persistence.cache.locationHandler"
             - '@Ibexa\Core\Persistence\Cache\Tag\CacheIdentifierGeneratorInterface'
+            - '%ezpublish_legacy.clear_all_spi_cache_on_symfony_clear_cache%'
+            - '%ezpublish_legacy.clear_all_spi_cache_from_legacy%'
         tags:
             - { name: kernel.cache_clearer }
         lazy: true


### PR DESCRIPTION
JIRA ticket: https://issues.ibexa.co/browse/IBX-1136

Make it configurable if
- clearing legacy cache ( view-cache) should also clear SPI cache
- running `bin/console cache:clear` should also clear SPI cache
