### PR TITLE
IBX-1228: Adapted `CacheGeneratorInterface` namespace

### DIFF
--- a/bundle/Cache/PersistenceCachePurger.php
+++ b/bundle/Cache/PersistenceCachePurger.php
@@ -10,7 +10,7 @@ use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandlerInterface;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
-use Ibexa\Core\Persistence\Cache\Tag\CacheIdentifierGeneratorInterface;
+use Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface;
 
 /**
  * Class PersistenceCachePurger.
@@ -44,7 +44,7 @@ class PersistenceCachePurger implements CacheClearerInterface
     protected $locationHandler;
 
     /**
-     * @var \Ibexa\Core\Persistence\Cache\Tag\CacheIdentifierGeneratorInterface
+     * @var \Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface
      */
     protected $cacheIdentifierGenerator;
 
@@ -70,7 +70,7 @@ class PersistenceCachePurger implements CacheClearerInterface
      *
      * @param \Symfony\Component\Cache\Adapter\TagAwareAdapterInterface $cache
      * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler (using SPI cache instance so calls are cached)
-     * @param \Ibexa\Core\Persistence\Cache\Tag\CacheIdentifierGeneratorInterface $cacheIdentifierGenerator
+     * @param \Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface $cacheIdentifierGenerator
      */
     public function __construct(
         TagAwareAdapterInterface $cache,

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -225,7 +225,7 @@ services:
         arguments:
             - "@ezpublish.cache_pool"
             - "@ezpublish.spi.persistence.cache.locationHandler"
-            - '@Ibexa\Core\Persistence\Cache\Tag\CacheIdentifierGeneratorInterface'
+            - '@Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface'
             - '%ezpublish_legacy.clear_all_spi_cache_on_symfony_clear_cache%'
             - '%ezpublish_legacy.clear_all_spi_cache_from_legacy%'
         tags:

--- a/bundle/Tests/Cache/PersistenceCachePurgerTest.php
+++ b/bundle/Tests/Cache/PersistenceCachePurgerTest.php
@@ -9,7 +9,7 @@ namespace eZ\Bundle\EzPublishLegacyBundle\Tests\Cache;
 use eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger;
 use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler;
-use Ibexa\Core\Persistence\Cache\Tag\CacheIdentifierGeneratorInterface;
+use Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -26,7 +26,7 @@ class PersistenceCachePurgerTest extends TestCase
     private $locationHandler;
 
     /**
-     * @var \Ibexa\Core\Persistence\Cache\Tag\CacheIdentifierGeneratorInterface|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $cacheIdentifierGenerator;
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "ezsystems/ezpublish-legacy-installer": "^2.0.4",
         "ezsystems/ezpublish-legacy": "^2019.03",
-        "ezsystems/ezpublish-kernel": "^7.5.21",
+        "ezsystems/ezpublish-kernel": "^7.5.24",
         "ezsystems/ezplatform-xmltext-fieldtype": "^1.8",
         "sensio/distribution-bundle": "^5.0.24",
         "twig/twig": "^1.35 || ^2.5"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "ezsystems/ezpublish-legacy-installer": "^2.0.4",
         "ezsystems/ezpublish-legacy": "^2019.03",
-        "ezsystems/ezpublish-kernel": "^7.5.24@dev",
+        "ezsystems/ezpublish-kernel": "^7.5.24",
         "ezsystems/ezplatform-xmltext-fieldtype": "^1.8",
         "sensio/distribution-bundle": "^5.0.24",
         "twig/twig": "^1.35 || ^2.5"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "ezsystems/ezpublish-legacy-installer": "^2.0.4",
         "ezsystems/ezpublish-legacy": "^2019.03",
-        "ezsystems/ezpublish-kernel": "^7.5.24",
+        "ezsystems/ezpublish-kernel": "^7.5.24@dev",
         "ezsystems/ezplatform-xmltext-fieldtype": "^1.8",
         "sensio/distribution-bundle": "^5.0.24",
         "twig/twig": "^1.35 || ^2.5"


### PR DESCRIPTION
This is a follow-up **depending on** https://github.com/ezsystems/ezpublish-kernel/pull/3122 to adapt the modified `CacheGeneratorInterface` namespace.